### PR TITLE
chore(npm scripts): add test-watch scripts to run tests with dev and …

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "test": "meteor test --once --driver-package dispatch:mocha-phantomjs",
     "test-app": "meteor test --full-app --once --driver-package dispatch:mocha-phantomjs",
     "test-watch": "meteor test --driver-package practicalmeteor:mocha --port 3100",
+    "test-watch:dev": "meteor --settings=config/development/settings.json test --driver-package practicalmeteor:mocha --port 3100",
+    "test-watch:prod": "meteor --settings=config/production/settings.json test --driver-package practicalmeteor:mocha --port 3100",
     "test-app-watch": "meteor test --full-app --driver-package practicalmeteor:mocha --port 3100",
     "prestart:dev": "echo \"load ENV variables like kadira\"",
     "start:dev": "meteor --settings=config/development/settings.json",


### PR DESCRIPTION
…prod configs

add two npm scripts to run test-watch with dev and prod configurations
certain collection schema are dependent on configuration and will throw if no configuration object is found