### PR TITLE
This merge includes fake document generators for all schema

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -73,3 +73,4 @@ email@1.1.18
 meteorhacks:ssr
 service-configuration@1.0.11
 shell-server@0.2.1
+xolvio:cleaner

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -136,3 +136,4 @@ url@1.0.11
 velocityjs:velocityjs@1.2.1
 webapp@1.3.12
 webapp-hashing@1.0.9
+xolvio:cleaner@0.3.1

--- a/imports/api/collectives/Collectives.tests.js
+++ b/imports/api/collectives/Collectives.tests.js
@@ -1,0 +1,22 @@
+import { Meteor } from 'meteor/meteor';
+import { resetDatabase } from 'meteor/xolvio:cleaner'
+import { Factory } from 'meteor/dburles:factory'
+import { fakerSchema } from '../../utils/test-utils/faker-schema/'
+import { Collectives } from './Collectives'
+
+const { schema, generateDoc } = fakerSchema
+
+Factory.define('collective', Collectives)
+
+describe('collectives module', function() {
+  beforeEach(function() {
+    resetDatabase()
+  })
+
+  // sanity check that jsf schema validaes ok
+  it('inserts cleanly', function() {
+    const testDoc = generateDoc(schema.Collective)
+    //console.log(testDoc)
+    const collective = Factory.create('collective', testDoc)
+  })
+})

--- a/imports/api/contracts/Contracts.tests.js
+++ b/imports/api/contracts/Contracts.tests.js
@@ -1,0 +1,23 @@
+import { Meteor } from 'meteor/meteor';
+import { resetDatabase } from 'meteor/xolvio:cleaner'
+import { Factory } from 'meteor/dburles:factory'
+import { fakerSchema } from '../../utils/test-utils/faker-schema/'
+import { Contracts } from './Contracts'
+
+
+const { schema, generateDoc } = fakerSchema
+
+Factory.define('contract', Contracts)
+
+describe('contracts module', function() {
+  beforeEach(function() {
+    resetDatabase()
+  })
+
+  // sanity check that jsf schema validaes ok
+  it('inserts cleanly', function() {
+    const testDoc = generateDoc(schema.Contract)
+    //console.log(testDoc)
+    const contract = Factory.create('contract', testDoc)
+  })
+})

--- a/imports/api/tags/Tags.tests.js
+++ b/imports/api/tags/Tags.tests.js
@@ -1,0 +1,22 @@
+import { Meteor } from 'meteor/meteor';
+import { resetDatabase } from 'meteor/xolvio:cleaner'
+import { Factory } from 'meteor/dburles:factory'
+import { fakerSchema } from '../../utils/test-utils/faker-schema/'
+import { Tags } from './Tags'
+
+const { schema, generateDoc } = fakerSchema
+
+Factory.define('tag', Tags)
+
+describe('tags module', function() {
+  beforeEach(function() {
+    resetDatabase()
+  })
+
+  // sanity check that jsf schema validaes ok
+  it('inserts cleanly', function() {
+    const testDoc = generateDoc(schema.Tag)
+    console.log(testDoc)
+    const tag = Factory.create('tag', testDoc)
+  })
+})

--- a/imports/api/transactions/Transactions.tests.js
+++ b/imports/api/transactions/Transactions.tests.js
@@ -1,0 +1,22 @@
+import { Meteor } from 'meteor/meteor';
+import { resetDatabase } from 'meteor/xolvio:cleaner'
+import { Factory } from 'meteor/dburles:factory'
+import { fakerSchema } from '../../utils/test-utils/faker-schema/'
+import { Transactions } from './Transactions'
+
+const { schema, generateDoc } = fakerSchema
+
+Factory.define('transaction', Transactions)
+
+describe('transactions module', function() {
+  beforeEach(function() {
+    resetDatabase()
+  })
+
+  // sanity check that jsf schema validaes ok
+  it('inserts cleanly', function() {
+    const testDoc = generateDoc(schema.Transaction)
+    //console.log(testDoc)
+    const transaction = Factory.create('transaction', testDoc)
+  })
+})

--- a/imports/utils/test-utils/faker-schema/Ballot.js
+++ b/imports/utils/test-utils/faker-schema/Ballot.js
@@ -1,0 +1,25 @@
+export const Ballot = {
+  type: 'object',
+  properties: {
+    _id: {
+      type: 'string'
+    },
+    mode: {
+      type: 'string'
+    },
+    rank: {
+      type: 'number'
+    },
+    url: {
+      type: 'string',
+      faker: 'internet.url'
+    },
+    label: {
+      type: 'string'
+    }
+  },
+  required: [
+    '_id',
+    'mode'
+  ]
+}

--- a/imports/utils/test-utils/faker-schema/Collective.js
+++ b/imports/utils/test-utils/faker-schema/Collective.js
@@ -1,0 +1,149 @@
+import { Wallet } from './Wallet'
+
+export const Country = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      faker: 'address.country'
+    },
+    code: {
+      type: 'string',
+      faker: 'address.countryCode'
+    }
+  },
+  required: [
+    'name',
+    'code'
+  ]
+}
+
+export const Jurisdiction = {
+  type: 'object',
+  properties: {
+    legal: {
+      type: 'object',
+      properties: {
+        taxId: {
+          type: 'string'
+        },
+        name: {
+          type: 'string'
+        },
+        type: {
+          type: 'string'
+        }
+      },
+      required: [
+        'name'
+      ]
+    },
+    location: {
+      type: 'object',
+      properties: {
+        address: {
+          type: 'string'
+        },
+        state: {
+          type: 'string',
+          faker: 'address.state'
+        },
+        country: {
+          type: Country
+        }
+      }
+    }
+  }
+}
+
+export const CollectiveProfile = {
+  type: 'object',
+  properties: {
+    website: {
+      type: 'string',
+      faker: 'internet.url'
+    },
+    bio: {
+      type: 'string'
+    },
+    blockchain: {
+      type: 'object',
+      properties: {
+        address: {
+          type: 'string'
+        }
+      }
+    },
+    logo: {
+      type: 'string'
+    },
+    jurisdiction: {
+      type: Jurisdiction
+    },
+    foundation: {
+      faker: 'date.past'
+    },
+    goal: {
+      enum: ['Profit', 'Free']
+    },
+    owners: {
+      type: 'string'
+    },
+    configured: {
+      type: 'boolean'
+    },
+    wallet: Wallet
+  },
+}
+
+export const Collective = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string'
+    },
+    domain: {
+      type: 'string'
+    },
+    emails: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          address: {
+            type: 'string',
+            faker: 'internet.email'
+          },
+          verified: {
+            type: 'boolean'
+          }
+        },
+        required: [
+          'address',
+          'verified'
+        ]
+      }
+    },
+    profile: {
+      type: CollectiveProfile
+    },
+    goal: {
+      enum: ['Business', 'Free', 'Commons']
+    },
+    authorities: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          userId: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  },
+  required: [
+    'name',
+    'domain'
+  ]
+}

--- a/imports/utils/test-utils/faker-schema/Contract.js
+++ b/imports/utils/test-utils/faker-schema/Contract.js
@@ -1,0 +1,247 @@
+import { Thread } from './Thread'
+import { Wallet } from './Wallet'
+import { faker } from 'faker'
+
+const genKeyword = () => `${faker.address.country()} ${faker.address.state()} ${faker.company.companyName()}`
+
+export const Contract = {
+  type: 'object',
+  properties: {
+    ID: {
+      type: 'string'
+    },
+    collectiveId: {
+      type: 'string'
+    },
+    title: {
+      type: 'string'
+    },
+    keyword: {
+      type: 'string'
+    },
+    kind: {
+      enum: [
+        'DRAFT',
+        'VOTE',
+        'DELEGATION',
+        'MEMBERSHIP'
+      ]
+    },
+    context: {
+      enum: [
+        'GLOBAL',
+        'LOCAL'
+      ]
+    },
+    url: {
+      type: 'string'
+    },
+    description: {
+      type: 'string'
+    },
+    createdAt: {
+      faker: 'date.past'
+    },
+    lastUpdate: {
+      faker: 'date.past'
+    },
+    timestamp: {
+      faker: 'date.past'
+    },
+    tags: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+         _id: {
+           type: 'string'
+         },
+         label: {
+           type: 'string'
+         },
+         url: {
+           type: 'string',
+           faker: 'internet.url'
+         },
+         rank: {
+           type: 'number'
+         }
+       },
+       required: ['_id']
+      }
+    },
+    membersOnly: {
+      type: 'boolean'
+    },
+    executionStatus: {
+      enum: [
+        'OPEN',
+        'APPROVED',
+        'ALTERNATIVE',
+        'REJECTED',
+        'VOID'
+      ]
+    },
+    anonymous: {
+      type: 'boolean'
+    },
+    signatures: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          _id: {
+            type: 'string'
+          },
+          username: {
+            type: 'string'
+          },
+          role: {
+            enum: [
+              'AUTHOR',
+              'DELEGATOR',
+              'DELEGATE',
+              'ENDORSER'
+            ]
+          },
+          status: {
+            enum: [
+              'PENDING',
+              'REJECTED',
+              'CONFIRMED'
+            ]
+          },
+          hash: {
+            type: 'string'
+          }
+        },
+        required: [
+          '_id'
+        ]
+      }
+    },
+    closingDate: {
+      faker: 'date.future'
+    },
+    alwaysOpen: {
+      type: 'boolean'
+    },
+    allowForks: {
+      type: 'boolean'
+    },
+    secretVotes: {
+      type: 'boolean'
+    },
+    realtimeResults: {
+      type: 'boolean'
+    },
+    multipleChoice: {
+      type: 'boolean'
+    },
+    rankPreferences: {
+      type: 'boolean'
+    },
+    executiveDecision: {
+      type: 'boolean'
+    },
+    stage: {
+      enum: [
+        'DRAFT',
+        'LIVE',
+        'FINISH'
+      ]
+    },
+    transferable: {
+      type: 'boolean'
+    },
+    limited: {
+      type: 'boolean'
+    },
+    portable: {
+      type: 'boolean'
+    },
+    ballot: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          _id: {
+            type: 'string',
+          },
+          rank: {
+            type: 'number'
+          },
+          url: {
+            type: 'string',
+            faker: 'internet.url'
+          },
+          label: {
+            type: 'string'
+          }
+        },
+        required: [
+          '_id',
+          'rank',
+          'url'
+        ]
+      }
+    },
+    ballotEnabled: {
+      type: 'boolean'
+    },
+    authorized: {
+      type: 'boolean'
+    },
+    isDefined: {
+      type: 'boolean'
+    },
+    isRoot: {
+      type: 'boolean'
+    },
+    referrers: {
+      type: 'array',
+      items: {
+        type: 'object'
+      }
+    },
+    events: {
+      type: 'array',
+      items: Thread
+    },
+    wallet: Wallet,
+    owner: {
+      pattern: '^[23456789ABCDEFGHJKLMNPQRSTWXYZabcdefghijkmnopqrstuvwxyz]{17}$'
+    }
+  },
+  required: [
+    'ID',
+    'title',
+    'keyword',
+    'kind',
+    'context',
+    'url',
+    'description',
+    'createdAt',
+    'lastUpdate',
+    'timestamp',
+    'membersOnly',
+    'executionStatus',
+    'anonymous',
+    'closingDate',
+    'alwaysOpen',
+    'allowForks',
+    'secretVotes',
+    'realtimeResults',
+    'multipleChoice',
+    'rankPreferences',
+    'executiveDecision',
+    'stage',
+    'ballotEnabled',
+    'authorized',
+    'isDefined',
+    'isRoot',
+    'events',
+    'wallet',
+    'owner'
+  ]
+}

--- a/imports/utils/test-utils/faker-schema/Tag.js
+++ b/imports/utils/test-utils/faker-schema/Tag.js
@@ -1,0 +1,47 @@
+import jsf from 'json-schema-faker'
+
+export const Tag = {
+  type: 'object',
+  properties: {
+    text: {
+      type: 'string'
+    },
+    keyword: {
+      faker: {
+        "helpers.slugify": [jsf({ faker: 'hacker.phrase' })]
+      }
+    },
+    url: {
+      faker: 'internet.url'
+    },
+    authors: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          _id: {
+            type: 'string'
+          }
+        },
+        required: ['_id']
+      }
+    },
+    createdAt: {
+      faker: 'date.past'
+    },
+    lastUpdate: {
+      faker: 'date.past'
+    },
+    authorized: {
+      type: 'boolean'
+    }
+  },
+  required: [
+    'text',
+    'keyword',
+    'url',
+    'createdAt',
+    'lastUpdate',
+    'authorized'
+  ]
+}

--- a/imports/utils/test-utils/faker-schema/Thread.js
+++ b/imports/utils/test-utils/faker-schema/Thread.js
@@ -1,0 +1,114 @@
+export const Thread = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string',
+    },
+    userId: {
+      type: 'string',
+    },
+    action: {
+      enum: [
+        'COMMENT',
+        'VOTE',
+        'SORT',
+        'REPLY'
+      ]
+    },
+    children: {
+      type: 'array',
+      items: {
+        type: Thread
+      }
+    },
+    ballot: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          _id: {
+            type: 'string'
+          },
+          mode: {
+            type: 'string'
+          },
+          rank: {
+            type: 'number'
+          },
+          url: {
+            type: 'string',
+            faker: 'internet.url'
+          },
+          label: {
+            type: 'string'
+          }
+        },
+        required: [
+          '_id',
+          'mode',
+          'rank'
+        ]
+      }
+    },
+    placedVotes: {
+      type: 'number',
+      minimum: 0
+    },
+    hasQuote: {
+      type: 'boolean'
+    },
+    quote: {
+      type: 'string'
+    },
+    content: {
+      type: 'string'
+    },
+    sort: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          upvotes: {
+            type: 'number',
+            minimum: 0
+          },
+          downvotes: {
+            type: 'number',
+            minimum: 0
+          },
+          userId: {
+            type:'string'
+          }
+        },
+        required: [
+          'upvotes',
+          'downvotes',
+          'userId'
+        ]
+      }
+    },
+    sortTotal: {
+      type: 'number',
+      minimum: 0
+    },
+    timestamp: {
+      type: 'string',
+      faker: 'date.past'
+    },
+    status: {
+      enum: [
+        'NEW',
+        'VERIFIED',
+        'PROCESSED'
+      ]
+    }
+  },
+  required: [
+    'id',
+    'action',
+    'children',
+    'content',
+    'timestamp',
+    'status'
+  ]
+}

--- a/imports/utils/test-utils/faker-schema/Transaction.js
+++ b/imports/utils/test-utils/faker-schema/Transaction.js
@@ -1,0 +1,110 @@
+import { Ballot } from './Ballot'
+
+export const Ticket = {
+  type: 'object',
+  properties: {
+    entityId: {
+      type: 'string'
+    },
+    address: {
+      type: 'string'
+    },
+    entityType: {
+      enum: [
+        'INDIVIDUAL',
+        'COLLECTIVE',
+        'CONTRACT',
+        'UNKNOWN'
+      ]
+    },
+    quantity: {
+      type: 'number',
+      minimum: 0
+    },
+    currency: {
+      enum: [
+        'BITCOIN',
+        'SATOSHI',
+        'VOTES'
+      ]
+    }
+  },
+  required: [
+    'entityId',
+    'address',
+    'entityType',
+    'quantity',
+    'currency'
+  ]
+}
+
+export const Transaction = {
+  type: 'object',
+  properties: {
+    input: Ticket,
+    output: Ticket,
+    kind: {
+      enum: [
+        'VOTE',
+        'DELEGATION',
+        'MEMBERSHIP',
+        'UNKNOWN'
+      ]
+    },
+    contractId: {
+      type: 'string'
+    },
+    timestamp: {
+      type: 'string',
+      faker: 'date.past'
+    },
+    condition: {
+      type: 'object',
+      properties: {
+        expiration: {
+          type: 'string',
+          faker: 'date.future'
+        },
+        transferable: {
+          type: 'boolean'
+        },
+        portable: {
+          type: 'boolean'
+        },
+        ballot: {
+          type: 'array',
+          items: {
+            type: Ballot
+          }
+        },
+        tags: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              status: {
+                enum: [
+                  'PENDING',
+                  'REJECTED',
+                  'CONFIRMED'
+                ]
+              }
+            },
+            required: [
+              'status'
+            ]
+          }
+        }
+      },
+      required: [
+        'expiration',
+        'transferable',
+        'portable'
+      ]
+    }
+  },
+  required: [
+    'input',
+    'output'
+  ]
+}

--- a/imports/utils/test-utils/faker-schema/User.js
+++ b/imports/utils/test-utils/faker-schema/User.js
@@ -1,0 +1,136 @@
+import { Wallet } from './Wallet';
+import { Country } from './Collective';
+
+export const Credential = {
+  type: 'object',
+  properties: {
+    source: {
+      enum: ['facebook', 'twitter', 'linkedin', 'github', 'peer'],
+    },
+    URL: {
+      faker: 'internet.url'
+    },
+    validated: {
+      type: 'boolean'
+    }
+  }
+}
+
+export const Menu = {
+  type: 'object',
+  properties: {
+    feed: 'all',
+    lastView: {
+      faker: 'date.past'
+    },
+    newItems: {
+      type: 'number',
+      minimum: 0
+    }
+  }
+}
+
+export const Profile = {
+  type: 'object',
+  properties: {
+    firstName: {
+      faker: 'name.firstName',
+    },
+    lastName: {
+      faker: 'name.lastName'
+    },
+    picture: {
+      faker: 'image.imageUrl'
+    },
+    country: Country,
+    birthday: {
+      faker: 'date.past'
+    },
+    gender: {
+      enum: ['Male', 'Female']
+    },
+    organization : {
+      faker: 'company.companyName'
+    },
+    website: {
+      faker: 'internet.url'
+    },
+    bio: {
+      type: 'string'
+    },
+    configured: {
+      type: 'boolean',
+    },
+    credentials: {
+      type: 'array',
+      items: {
+        type: Credential
+      }
+    },
+    url: {
+      faker: 'internel.url'
+    },
+    menu: {
+      type: 'array',
+      items: {
+        type: Menu
+      }
+    },
+    wallet: Wallet
+  }
+}
+
+export const User = {
+  type: 'object',
+  properties: {
+    username: {
+      faker: 'internet.userName'
+    },
+    emails: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          address: {
+            faker: 'internet.email'
+          },
+          verified: {
+            type: 'boolean'
+          }
+        },
+        required: [
+          'address',
+          'verified'
+        ]
+      }
+    },
+    registered_emails: {
+      type: 'array',
+      items: {
+        type: 'object'
+      }
+    },
+    createdAt: {
+      faker: 'date.past'
+    },
+    profile: {
+      type: Profile
+    },
+    services: {
+      type: 'object'
+    },
+    roles: {
+      type: 'object'
+    },
+    roles: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    },
+    heartbeat: {
+      faker: 'date.past'
+    }
+  },
+  required: ['createdAt']
+}

--- a/imports/utils/test-utils/faker-schema/Vote.js
+++ b/imports/utils/test-utils/faker-schema/Vote.js
@@ -1,0 +1,66 @@
+import { Wallet } from './Wallet'
+
+export const DelegationContract = {
+  type: 'object',
+  properties: {
+    collectiveId: {
+      type: 'string',
+    },
+    delegatorId: {
+      type: 'string'
+    },
+    contractId: {
+      type: 'string'
+    },
+    votes: {
+      type: 'number',
+      minimum: 0
+    },
+    tags: {
+      type: Array,
+      items: {
+        type: 'object',
+        properties: {
+          _id: {
+            type: 'string'
+          },
+          text: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  }
+}
+
+export const Delegation = {
+  received: {
+    type: 'array',
+    items: {
+      type: DelegationContract
+    }
+  },
+  sent: {
+    type: 'array',
+    items: {
+      type: DelegationContract
+    }
+  }
+}
+
+export const Vote = {
+  type: 'object',
+  properties: {
+    total: {
+      type: 'number',
+      minimum: 0
+    },
+    delegations: {
+      type: Delegation
+    },
+    wallet: Wallet
+  },
+  required: [
+    'total'
+  ]
+}

--- a/imports/utils/test-utils/faker-schema/Wallet.js
+++ b/imports/utils/test-utils/faker-schema/Wallet.js
@@ -1,0 +1,75 @@
+import { Ballot } from './Ballot'
+
+export const Wallet = {
+  type: 'object',
+  properties: {
+    balance: {
+      type: 'number',
+      minimum: 0
+    },
+    placed: {
+      type: 'number',
+      minimum: 0
+    },
+    available: {
+      type: 'number',
+      minimum: 0
+    },
+    currency: {
+      enum: [
+        'BITCOIN',
+        'SATOSHI',
+        'VOTES'
+      ]
+    },
+    address: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          hash: {
+            type: 'string'
+          },
+          collectiveId: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    ledger: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          txId: {
+            type: 'string'
+          },
+          quantity: {
+            type: 'number'
+          },
+          entityId: {
+            enum: [
+              'BITCOIN',
+              'SATOSHI',
+              'VOTES'
+            ]
+          },
+          ballot: {
+            type: 'array',
+            items: {
+              type: Ballot
+            }
+          }
+        }
+      }
+    }
+  },
+  required: [
+    'balance',
+    'placed',
+    'available',
+    'currency',
+    'address',
+    'ledger'
+  ]
+}

--- a/imports/utils/test-utils/faker-schema/index.js
+++ b/imports/utils/test-utils/faker-schema/index.js
@@ -1,0 +1,38 @@
+import jsf from 'json-schema-faker'
+import { Ballot } from './Ballot'
+import {
+  Country,
+  Jurisdiction,
+  CollectiveProfile,
+  Collective
+} from './Collective'
+import { Contract } from './Contract'
+import { Thread } from './Thread'
+import { Transaction } from './Transaction'
+import { Wallet } from './Wallet'
+import { Credential, Menu, Profile, User } from './User'
+import { Tag } from './Tag'
+import { DelegationContract, Delegation, Vote } from './Vote'
+
+export const fakerSchema = {
+  generateDoc: jsf,
+  schema: {
+    Ballot,
+    Country,
+    Jurisdiction,
+    CollectiveProfile,
+    Collective,
+    Contract,
+    Thread,
+    Transaction,
+    Wallet,
+    Credential,
+    Menu,
+    Profile,
+    User,
+    Tag,
+    DelegationContract,
+    Delegation,
+    Vote
+  }
+}

--- a/imports/utils/test-utils/index.js
+++ b/imports/utils/test-utils/index.js
@@ -1,0 +1,1 @@
+export { fakerSchema } from './faker-schema'


### PR DESCRIPTION
A few things to note:

- The /imports/api/*/*.tests.js files only include sanity checks to make sure the generate documents validate and insert, they do not include any bona fide unit tests.
- /imports/utils/test-utils/ exports the object fakerSchema which has two properties, 'schema' and 'generateDoc', where 'schema' is an object containing all the fake document schema and 'generateDoc' is simply the renamed version of the 'json-schema-faker' export. This is so you do not need to import 'json-schema-faker' into your unit tests if you don't need it.
- You **should not** register a generated document using Factory.define in your unit tests unless you only wish to unit test a single document on every invocation of Factory.create or Factory.build. Rather, pass generateDoc(<schema>) as the second arg to those calls.

Hopefully, this helps speed up the addition of unit tests across the board.

Let me know your thoughts.