### PR TITLE
Makes login popup disappear if user clicks outside of it

### DIFF
--- a/imports/ui/templates/layout/main.js
+++ b/imports/ui/templates/layout/main.js
@@ -23,6 +23,8 @@ import { TAPi18n } from 'meteor/tap:i18n';
 import { $ } from 'meteor/jquery';
 import { Session } from 'meteor/session';
 import { SearchSource } from 'meteor/meteorhacks:search-source';
+import { Template } from 'meteor/templating';
+import { displayLogin } from '/imports/ui/modules/popup';
 
 import { globalObj } from '/lib/global';
 import './main.html';
@@ -74,4 +76,18 @@ Meteor.startup(() => {
     globalObj.geoJSON = result.data;
     Session.set('filteredCountries', result.data.country);
   });
+});
+
+Template.main.events({
+  'mouseup #content'(event) {
+    if (Session.get('displayPopup')) {
+      if (event.target.parentElement.id !== 'loggedUser') {
+        if (event.target.id !== 'loggedUser') {
+          if (event.target.id !== 'agora-login') {
+            displayLogin(event);
+          }
+        }
+      }
+    }
+  },
 });


### PR DESCRIPTION
I noticed the login-popup can be opened from a couple of places. This PR allows the popup to hide or disappear if a user clicks outside of the popup itself. I opted for adding an event listener in the general `main.js`. Is this the best way to go about it? 

I tested locally and it seems to be working fine. I followed the [CONTRIBUTIND.md](https://github.com/DemocracyEarth/sovereign/blob/master/CONTRIBUTING.md) doc and ran the test suite. Errors do show up but they don't seem to be related to my commit. 

I can add comments to the added code if necessary.

This closes #58 
