### PR TITLE
Basic handling for bad URLs

### DIFF
--- a/imports/startup/client/routes.js
+++ b/imports/startup/client/routes.js
@@ -5,6 +5,7 @@ import { TAPi18n } from 'meteor/tap:i18n';
 
 import '/imports/ui/templates/layout/main.js';
 import '/imports/ui/templates/layout/url/home/home.js';
+import '/imports/ui/templates/layout/url/notFound/notFound.js';
 import '/imports/ui/templates/layout/load/load.js';
 import '/imports/ui/templates/components/identity/login/login.js';
 import '/imports/ui/templates/components/identity/card/card.js';
@@ -19,6 +20,7 @@ import { fn } from './functions';
 Router.configure({
   layoutTemplate: 'main',
   loadingTemplate: 'load',
+  notFoundTemplate: 'notFound',
 });
 
 /*
@@ -59,11 +61,15 @@ Router.route('/:feed', {
     return [Meteor.subscribe('contracts', fn.buildQuery(this.params.query)), Meteor.subscribe('userData')];
   },
   onBeforeAction() {
-    fn.clearSessionVars();
-    fn.configNavbar(fn.buildTitle(this.params.query));
-    fn.setSessionVars(this.params);
-    Session.set('feed', Contracts.find(fn.buildQuery(this.params.query), { sort: { timestamp: -1 } }).fetch());
-    this.next();
+    if (this.params.feed === 'feed') {
+      fn.clearSessionVars();
+      fn.configNavbar(fn.buildTitle(this.params.query));
+      fn.setSessionVars(this.params);
+      Session.set('feed', Contracts.find(fn.buildQuery(this.params.query), { sort: { timestamp: -1 } }).fetch());
+      this.next();
+    } else {
+      this.render('notFound');
+    }
   },
   onAfterAction() {
     fn.getExternalScripts();
@@ -89,12 +95,6 @@ Router.route('/tag/:tag', {
   onAfterAction() {
     fn.getExternalScripts();
   },
-});
-
-// TODO: figure out what to do when no param is given
-Router.route('/peer', {
-  name: 'peer',
-  template: 'peer',
 });
 
 /*

--- a/imports/ui/templates/layout/url/notFound/notFound.html
+++ b/imports/ui/templates/layout/url/notFound/notFound.html
@@ -1,0 +1,5 @@
+<template name="notFound">
+  <div class="content content-feed">
+    <p>Looks like that page does not exist</p>
+  </div>
+</template>

--- a/imports/ui/templates/layout/url/notFound/notFound.js
+++ b/imports/ui/templates/layout/url/notFound/notFound.js
@@ -1,0 +1,1 @@
+import './notFound.html';


### PR DESCRIPTION
Here's what I found: 

* Looks like there is [no correct way (or even working?) way of handling real 404s](http://stackoverflow.com/questions/27001298/how-to-return-404-using-iron-router) right now with Iron Router. 
* There's an [issue](https://github.com/iron-meteor/iron-router/issues/1055) along with its respective [PR](https://github.com/iron-meteor/iron-router/pull/1505) that have both been open for a while. 
* This all points to the fact that [Iron Route may be dying out to FlowRouter](https://themeteorchef.com/blog/the-state-of-routing-in-meteor/):
>One other difference—and perhaps the elephant in the room—is that the Iron Router project has started to slow down a bit in terms of active development and response to issues. While there hasn't been any official statement around whether or not work on the project will continue, many have expressed concern about this. Flow Router, in contrast, is seeing a lot of active development

With that in mind, this PR does a _very_ basic handling of bad URLs: it renders a `notFound` template but still gives a 200 HTTP status. All URLs with the form of `localhost:3000/somethingrandom` or `localhost:3000/some/randomorunknonw/path` render the `notFound` template. Note that this takes care of `localhost:3000/peer` (which was a TODO in `routes.js`). 

URLs with the form of `localhost:3000/vote/whatver`, `localhost:3000/peer/whatever`, etcetera, currently just show an empty template (with no errors). I'm suggesting to leave it this way for now, because the current solution just feels too hacky. Longer term, it might be best to migrate to FlowRouter. 

Fixes #84 


