### PR TITLE
Add license and repository metadata to package configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,9 @@
 {
+  "license" : "MIT",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/DemocracyEarth/sovereign.git"
+  },
   "scripts": {
     "start": "meteor --settings=config/production/settings.json",
     "pretest": "npm run lint --silent",


### PR DESCRIPTION
> When your are ready to share your code, run the test suite:
> 
>     $ meteor npm run test
>     $ meteor npm run test-app
> 
> and ensure all tests pass.

_Neither pass on my setup,_ but I'm pushing the PR anyway :eyes: 

---

**This PR calls for discussion** ; the supplied repository is over here at github. One could argue that the whole development stack should be as **libre** and **transparent** as reasonably achievable. Code hosting and issue handling is also pretty well done by the libre [gitlab](https://fr.wikipedia.org/wiki/GitLab_CE) and at least [one nonprofit](https://framagit.org/public/projects) host, maintain and run an instance of it for free for open projects such as sovereign.

_This perhaps even calls for polling?_
