### PR TITLE
Issue 105: bcrypt->bcryptjs for Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "autoprefixer": "^6.4.1",
     "babel-runtime": "^6.18.0",
-    "bcrypt": "^0.8.7",
+    "bcryptjs": "^2.4.0",
     "bindings": "^1.2.1",
     "core-js": "^2.4.1",
     "faker": "^3.0.1",


### PR DESCRIPTION
bcrypt is compiled for *nix kernels only. This change uses native JS version of bcrypt to allow support for Windows.

Note that this does come at a cost - bcrypt performance is about 2.7x faster in the C++ *nix implementation vs this native JS implementation, see [the documentation](https://www.npmjs.com/package/bcryptjs). If this is not acceptable, you should probably officially drop support for Windows.