### PR TITLE
Allows users to complete login by pressing 'enter'

### DIFF
--- a/imports/ui/templates/components/identity/login/emailLogin.html
+++ b/imports/ui/templates/components/identity/login/emailLogin.html
@@ -22,9 +22,9 @@
                 {{> warning label="user-not-found"}}
               </div>
             {{/if}}
-            <div id="signin-button" class="button login-button">
+            <button type="submit" id="signin-button" class="button login-button">
               <div>{{_ 'sign-in'}}</div>
-            </div>
+            </button>
           </form>
         </div>
         <div>

--- a/imports/ui/templates/components/identity/login/emailLogin.js
+++ b/imports/ui/templates/components/identity/login/emailLogin.js
@@ -36,7 +36,8 @@ Template.emailLogin.events({
   "click #forgot-pw": function (event) {
     Session.set("passwordKnown", !Session.get("passwordKnown"));
   },
-  "click #signin-button": function (event) {
+  "click #signin-button, submit #email-signin-form": function (event) {
+    event.preventDefault();
     var email = document.getElementById('signin-email').value;
     var pass = document.getElementById('signin-password').value;
 


### PR DESCRIPTION
Right now when logging in (via the log-in pop up) a user has to click the 'Sign in' button. Pressing 'enter' on keyboard is simply unresponsive. This PR addresses that and closes #111.

