### PR TITLE
Imports Accounts correctly

### DIFF
--- a/imports/ui/templates/components/identity/login/forgotPassword.js
+++ b/imports/ui/templates/components/identity/login/forgotPassword.js
@@ -1,53 +1,52 @@
 import { Session } from 'meteor/session';
 import { Template } from 'meteor/templating';
-import { Accounts } from 'meteor/accounts-password';
+import { Accounts } from 'meteor/accounts-base';
 
 import './forgotPassword.html';
 import '../../../widgets/warning/warning.js';
 
 Template.forgotPassword.rendered = function rendered() {
-  Session.set("emailSent", false);
-  Session.set("error1", false);
-  Session.set("error2", false);
-}
+  Session.set('emailSent', false);
+  Session.set('error1', false);
+  Session.set('error2', false);
+};
 
 Template.forgotPassword.helpers({
   emailSent: function () {
-    return Session.get("emailSent");
+    return Session.get('emailSent');
   },
   error1: function () {
-    return Session.get("error1");
+    return Session.get('error1');
   },
   error2: function () {
-    return Session.get("error2");
-  }
+    return Session.get('error2');
+  },
 });
 
 Template.forgotPassword.events({
-  "click #recovery-button": function (event){
-    console.log("onClick: recovery-button");
+  "click #recovery-button": function (event) {
 
-    //Get recovery email
-    var email = document.getElementById('recovery-email').value;
+    // Get recovery email
+    const email = document.getElementById('recovery-email').value;
 
-    //Reset helpers in case #recovery-button is clicked multiple times
-    Session.set("emailSent", false);
-    Session.set("error1", false);
-    Session.set("error2", false);
+    // Reset helpers in case #recovery-button is clicked multiple times
+    Session.set('emailSent', false);
+    Session.set('error1', false);
+    Session.set('error2', false);
 
-    //Validate non-empty email & invoke Passwords API
-    if (email != '') {
-      Accounts.forgotPassword({email: email}, function(err) {
+    // Validate non-empty email & invoke Passwords API
+    if (email !== '') {
+      Accounts.forgotPassword({ email: email }, function (err) {
         if (err) {
           if (err.message === 'User not found [403]') {
-            Session.set("error1", true);
+            Session.set('error1', true);
           } else {
-            Session.set("error2", true);
+            Session.set('error2', true);
           }
         } else {
-          Session.set("emailSent", true);
+          Session.set('emailSent', true);
         }
       });
     }
-  }
+  },
 });


### PR DESCRIPTION
`Accounts.forgotPassword()` was producing an error because of a wrong import. The correct import in this case is `import { Accounts } from 'meteor/accounts-base';`.

All other changes in this commit are just syntax style modifications (linter was yelling at me)

Fixes #115 