### PR TITLE
React migration: BlockchainLogin component

### DIFF
--- a/imports/ui/templates/components/identity/login/BlockchainLogin.jsx
+++ b/imports/ui/templates/components/identity/login/BlockchainLogin.jsx
@@ -16,8 +16,8 @@ export default class BlockchainLogin extends Component {
   render() {
     return (
       <div className="login">
-        {TAPi18n.__('use-blockchain-id')}
-        <img src="/images/qrplaceholder.png" className="qr-code qr-sign" alt="qrplaceholder.png" onClick={this.handleQrSignin} />
+        <div dangerouslySetInnerHTML={{ __html: TAPi18n.__('use-blockchain-id') }} />
+        <img src="/images/qr.png" className="qr-code qr-sign" alt="qrplaceholder.png" onClick={this.handleQrSignin} />
         <div className="login-label">
           {TAPi18n.__('scan-with')} <a>{TAPi18n.__('phone-app')}</a>.
         </div>

--- a/imports/ui/templates/components/identity/login/BlockchainLogin.jsx
+++ b/imports/ui/templates/components/identity/login/BlockchainLogin.jsx
@@ -1,0 +1,27 @@
+import { Meteor } from 'meteor/meteor';
+import React, { Component } from 'react';
+import { TAPi18n } from 'meteor/tap:i18n';
+
+export default class BlockchainLogin extends Component {
+  constructor(props) {
+    super(props);
+
+    this.handleQrSignin = this.handleQrSignin.bind(this);
+  }
+
+  handleQrSignin() {
+    Meteor.loginWithPassword('napoleonDynamite', 'xdwcqc');
+  }
+
+  render() {
+    return (
+      <div className="login">
+        {TAPi18n.__('use-blockchain-id')}
+        <img src="/images/qrplaceholder.png" className="qr-code qr-sign" alt="qrplaceholder.png" onClick={this.handleQrSignin} />
+        <div className="login-label">
+          {TAPi18n.__('scan-with')} <a>{TAPi18n.__('phone-app')}</a>.
+        </div>
+      </div>
+    );
+  }
+}

--- a/imports/ui/templates/components/identity/login/blockchainLogin.html
+++ b/imports/ui/templates/components/identity/login/blockchainLogin.html
@@ -1,9 +1,5 @@
 <template name="blockchainLogin">
-  <div class="login">
-    {{{_ "use-blockchain-id"}}}
-    <img src="{{pathFor route='home'}}images/qrplaceholder.png" class="qr-code qr-sign">
-    <div class="login-label">
-      {{_ "scan-with"}} <a>{{_ "phone-app"}}</a>.
-    </div>
-  </div>
+	<div>
+		{{> React component=BlockchainLogin}}
+	</div>
 </template>

--- a/imports/ui/templates/components/identity/login/blockchainLogin.js
+++ b/imports/ui/templates/components/identity/login/blockchainLogin.js
@@ -1,10 +1,10 @@
-import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 
 import './blockchainLogin.html';
+import BlockchainLogin from './BlockchainLogin.jsx';
 
-Template.blockchainLogin.events({
-  'click .qr-sign'() {
-    Meteor.loginWithPassword('napoleonDynamite', 'xdwcqc');
+Template.blockchainLogin.helpers({
+  BlockchainLogin() {
+    return BlockchainLogin;
   },
 });


### PR DESCRIPTION
BlockchainLogin component implemented with React. 

I'm thinking all PRs to come related to the migration can be initially merged to `prj-9-blaze-to-react` (to serve as a sort of staging), and then merged to `master` right away or when deemed appropriate. This might not be completely necessary, but it gives a bit more organization. 

Related to #64 and [project 9](https://github.com/DemocracyEarth/sovereign/projects/9)

