### PR TITLE
Migrate Tag component to React

### DIFF
--- a/imports/ui/templates/components/decision/semantics/semantics.js
+++ b/imports/ui/templates/components/decision/semantics/semantics.js
@@ -39,13 +39,8 @@ Template.semantics.rendered = function rendered() {
           Session.set('maxReached', false);
           Session.set('duplicateTags', false);
         } else if (this.id == 'tagList') {
-          if (addTag(ui.item.get(0).getAttribute('value'), ui.item.index()) === true) {
-            const element = ui.item.get(0).childNodes[1].childNodes[6];
-            element.parentNode.removeChild(element);
-            ui.item.get(0).remove();
-          } else {
-            ui.item.get(0).remove();
-          }
+          addTag(ui.item.get(0).getAttribute('value'), ui.item.index());
+          ui.item.get(0).remove();
         }
       },
       revert: 100,

--- a/imports/ui/templates/components/decision/tag/Tag.jsx
+++ b/imports/ui/templates/components/decision/tag/Tag.jsx
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import React, { Component } from 'react';
 import { Session } from 'meteor/session';
 import { addTag } from '/lib/data';
+import { convertToSlug } from '../../../../../utils/functions';
 
 
 export default class Tag extends Component {
@@ -19,7 +20,7 @@ export default class Tag extends Component {
           <div className="hash-tag">{ content }</div>
         </a>
         { suggestion &&
-          <div className="action" onClick={() => this.addTagClick(id)}>
+          <div id={`add-suggested-tag-${convertToSlug(content)}`} className="action" onClick={() => this.addTagClick(id)}>
             <div>
               <strong>＋</strong>
             </div>

--- a/imports/ui/templates/components/decision/tag/Tag.jsx
+++ b/imports/ui/templates/components/decision/tag/Tag.jsx
@@ -1,0 +1,31 @@
+import { Meteor } from 'meteor/meteor';
+import React, { Component } from 'react';
+import { Session } from 'meteor/session';
+import { addTag } from '/lib/data';
+
+
+export default class Tag extends Component {
+  addTagClick(tagId) {
+    addTag(tagId, parseInt(Session.get('dbTagList').length) + 1)
+  }
+
+  render() {
+    const { suggestion, text, label, url, id } = this.props;
+    const content = suggestion ? text : label;
+    return (
+      <div className="tag-label">
+        <img src="/images/hashtag.png" className="hash-icon"/>
+        <a href={ url } className="w-clearfix w-inline-block hash-link">
+          <div className="hash-tag">{ content }</div>
+        </a>
+        { suggestion &&
+          <div className="action" onClick={() => this.addTagClick(id)}>
+            <div>
+              <strong>＋</strong>
+            </div>
+          </div>
+        }
+      </div>
+    );
+  }
+}

--- a/imports/ui/templates/components/decision/tag/tag.html
+++ b/imports/ui/templates/components/decision/tag/tag.html
@@ -1,21 +1,11 @@
 <template name="tag">
   <li class="w-clearfix tag {{authorization}} {{drag nonDraggable}}" id="draggable" value="{{../_id}}">
-    <div class="tag-label">
-      <img src="{{pathFor route='home'}}images/hashtag.png" class="hash-icon">
-      {{#if suggestion}}
-        <a href="{{../url}}" class="w-clearfix w-inline-block hash-link {{authorization hover=true}}">
-          <div class="hash-tag">{{{../text}}}</div>
-        </a>
-        <div id="add-suggested-tag" class="action">
-          <div>
-            <strong>＋</strong>
-          </div>
-        </div>
-      {{else}}
-        <a href="{{../url}}" class="w-clearfix w-inline-block hash-link {{authorization hover=true}}">
-          <div class="hash-tag">{{{../label}}}</div>
-        </a>
-      {{/if}}
-    </div>
+    {{> React component=Tag
+          suggestion=suggestion
+          url=../url
+          text=../text
+          label=../label
+          id=this._id
+    }}
   </li>
 </template>

--- a/imports/ui/templates/components/decision/tag/tag.js
+++ b/imports/ui/templates/components/decision/tag/tag.js
@@ -1,6 +1,5 @@
 import { Template } from 'meteor/templating';
-import { Session } from 'meteor/session';
-import { addTag } from '/lib/data';
+import Tag from './Tag.jsx';
 
 import './tag.html';
 
@@ -13,10 +12,7 @@ Template.tag.helpers({
       return 'tag-no-grab';
     }
   },
-});
-
-Template.tag.events({
-  'click #add-suggested-tag'(event) {
-    addTag(this._id, parseInt(Session.get('dbTagList').length) + 1);
-  },
+  Tag() {
+    return Tag;
+  }
 });


### PR DESCRIPTION
I wanted to contribute to this project for some time now and figured migrating components from Blaze to React could be a good way to get into it.

So this is the migration for the Tag component. Two notes :

1. In `semantics.js` manually removing the `+` action button from the tag didn't seems necessary anymore as component gets re-rendered automatically.

2. I kept the `<li>` tag in `tag.html` instead of writing it as root for `Tag.jsx` component because it caused a problem with Jquery-UI :
If I get things right, react components in Blaze templates must be wrapped inside a block. However Jquery-UI draggable expect the direct children of the sortable list root tags to contains the `value={...}` attribute.

Setting `<li>` as the root tag of the react component would have end up in a tree like this :
```
<ul id="tagList" class="w-list-unstyled w-clearfix connectedSortable ui-sortable">
    <div>
        <li class="w-clearfix tag authorized" id="draggable" value="y9Ea5E5mAsCfSsvB5">...</li>
    </div>
    <div>
        <li class="w-clearfix tag authorized" id="draggable" value="5T6FbB3w9uNMCb6Dm">...</li>
    </div>
</ul>
```

Related to #64 and [project 9](https://github.com/DemocracyEarth/sovereign/projects/9)