### PR TITLE
Makes popup to go away after login and logout

### DIFF
--- a/imports/ui/modules/popup.js
+++ b/imports/ui/modules/popup.js
@@ -127,7 +127,7 @@ const _cancel = (id) => {
 };
 
 /**
-/* @summary animate fade in or out of popup instnace
+/* @summary animate fade in or out of popup instance
 /* @param {boolean} display - if a fade in or fade out will be played
 /* @param {id} string popup identifier
 ***/

--- a/imports/ui/templates/components/identity/login/EmailLogin.jsx
+++ b/imports/ui/templates/components/identity/login/EmailLogin.jsx
@@ -56,8 +56,8 @@ export default class EmailLogin extends Component {
             this.handleSigninError();
             break;
         } else {
-+        // Successful login
-+        clearPopups();
+        // Successful login
+        clearPopups();
        }
       }
     });

--- a/imports/ui/templates/components/identity/login/EmailLogin.jsx
+++ b/imports/ui/templates/components/identity/login/EmailLogin.jsx
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import React, { Component } from 'react';
 import { TAPi18n } from 'meteor/tap:i18n';
+import { clearPopups } from '/imports/ui/modules/popup';
 import Warning from '../../../widgets/warning/Warning.jsx';
 import Signup from '../signup/Signup.jsx';
 import ForgotPassword from './ForgotPassword.jsx';
@@ -55,10 +56,10 @@ export default class EmailLogin extends Component {
             // User not found or incorrect password
             this.handleSigninError();
             break;
-        } else {
+        }
+      } else {
         // Successful login
         clearPopups();
-       }
       }
     });
   }

--- a/imports/ui/templates/components/identity/login/EmailLogin.jsx
+++ b/imports/ui/templates/components/identity/login/EmailLogin.jsx
@@ -55,7 +55,10 @@ export default class EmailLogin extends Component {
             // User not found or incorrect password
             this.handleSigninError();
             break;
-        }
+        } else {
++        // Successful login
++        clearPopups();
+       }
       }
     });
   }

--- a/imports/ui/templates/components/identity/login/login.js
+++ b/imports/ui/templates/components/identity/login/login.js
@@ -12,7 +12,7 @@ Template.login.events({
   'click #logout'() {
     // Session.set('displayPopup', false);
     Session.set('logger', false);
-    animatePopup(false);
+    animatePopup(false, `login-${Meteor.userId()}`);
     Meteor.logout();
     Router.go('/');
   },


### PR DESCRIPTION
I reviewed the following commits for context on the latest @santisiri did regarding the popup: 

4608b81efd07b08f73e50e235371421a0712cd3c
8e1c11bbafadf2de3978e3e190b85dc87b73a707
12358468a507313584e11578c9a1522ccad1f3e5
22a7c2af4b2a212777429fad691ece1e003395d3
d0db1963ab5e490bcaa27cba568438419c5e99ee

Issue right now is that the popup 'gets stuck' after login or logout. Per my understanding, looks like the main decision to make is whether we want the popup to remain visible after login or logout. That'd be a UX decision, there are probably benefits either way (visible or not). This PR makes the popup to go away after login or logout; user can click on the top-right corner icon to activate popup normally. 

@santisiri not sure if this is the use you had in mind for method `clearPopups()` of `popup.js`, I'm shadowing the way you use that method in `liquid.js`

This PR addresses #157 

Also sort of related to older PR #80 (currently the popup does not disappear if a user clicks outside of it)
