### PR TITLE
Fix modal popup mobile view

### DIFF
--- a/imports/startup/client/subscribe.js
+++ b/imports/startup/client/subscribe.js
@@ -1,4 +1,7 @@
 import { Meteor } from 'meteor/meteor';
+import initReactFastclick from 'react-fastclick';
+
+initReactFastclick();
 
 Meteor.subscribe('tags');
 Meteor.subscribe('collectives');

--- a/imports/ui/css/earth.css
+++ b/imports/ui/css/earth.css
@@ -7,6 +7,7 @@ body {
   font-size: 18px;
   line-height: 28px;
   font-weight: 300;
+  -webkit-tap-highlight-color: transparent;
 }
 
 h1 {

--- a/imports/ui/templates/components/identity/login/ForgotPassword.jsx
+++ b/imports/ui/templates/components/identity/login/ForgotPassword.jsx
@@ -68,11 +68,17 @@ export default class ForgotPassword extends Component {
           </div>
         </div>
         <div className="login">
-          <form onSubmit={this.handleSubmit}>
+          <form id="recover-password" name="forgot-password-form" onSubmit={this.handleSubmit}>
             <div className="w-clearfix login-field">
               <label htmlFor="name" className="login-label login-label-form">{TAPi18n.__('recovery-email')}</label>
               <img src="/images/mail-closed.png" className="login-icon" alt="mail-closed" />
               <input id="recovery-email" type="text" placeholder={TAPi18n.__('email-sample')} className="w-input login-input" />
+              {warning}
+            </div>
+            <div className="w-clearfix login-field">
+              <label htmlFor="name" className="login-label login-label-form">TESTING, TO REMOVE</label>
+              <img src="/images/mail-closed.png" className="login-icon" alt="mail-closed" />
+              <input id="recovery-email" type="text" placeholder="TESING, TO REMOVE" className="w-input login-input" />
               {warning}
             </div>
             <div type="submit" id="recovery-button" className="button login-button" onClick={this.handleSubmit}>

--- a/imports/ui/templates/components/identity/login/forgotPassword.js
+++ b/imports/ui/templates/components/identity/login/forgotPassword.js
@@ -1,7 +1,7 @@
 import { Template } from 'meteor/templating';
 
 import './forgotPassword.html';
-import { ForgotPassword } from './ForgotPassword.jsx';
+import ForgotPassword from './ForgotPassword.jsx';
 
 Template.forgotPassword.helpers({
   ForgotPassword() {

--- a/imports/ui/templates/widgets/popup/popup.js
+++ b/imports/ui/templates/widgets/popup/popup.js
@@ -9,18 +9,26 @@ import { animationSettings } from '/imports/ui/modules/animation';
 import './popup.html';
 
 function autoPosition(height) {
+  console.log('TEST - autoPosition()');
   const screenH = $(window).height();
   let pos = parseInt(((screenH - height) / 2) - 10, 10);
-  if (pos <= 70) { pos = 70; }
+  if (pos <= 70) { 
+    console.log('TEST - pos <=70');
+    pos = 70;
+  }
+  console.log('TEST - pos: ', pos);
   return pos;
 }
 
 Template.popup.onRendered(() => {
+  console.log('TEST - onRendered()');
   $(`#card-${Template.instance().data.id}`).attr('legacyheight', $(`#card-${Template.instance().data.id}`)[0].getBoundingClientRect().height);
   $(`#card-${Template.instance().data.id}`).resize(function () {
     if (Meteor.Device.isPhone()) {
       const divId = `#${this.id}`;
+      console.log('TEST - divId: ', divId);
       if (!$(divId).is('.velocity-animating')) {
+        console.log('TEST - invoke autoPosition from onRendered');
         const newMargin = autoPosition($(divId)[0].getBoundingClientRect().height);
         const newHeight = $(divId)[0].getBoundingClientRect().height;
         // $(divId).css('height', $(divId).attr('legacyheight'));
@@ -45,7 +53,11 @@ Template.popup.helpers({
     return Meteor.Device.isPhone();
   },
   modalPosition() {
+    console.log('TEST - modalPosition()');
     if (Session.get(this.id).position.height) {
+      console.log('TEST - true IF in modalPosition()');
+      console.log('TEST - this.id ', this.id);
+      console.log('TEST - invoke autoPosition from modalPosition');
       return `margin-top: ${autoPosition($(`#card-${this.id}`)[0].getBoundingClientRect().height)}px;`;
     }
     return '';

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "nan": "^2.3.5",
     "react": "^15.6.2",
     "react-addons-pure-render-mixin": "^15.6.2",
-    "react-dom": "^15.6.2"
+    "react-dom": "^15.6.2",
+    "react-fastclick": "^3.0.2"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.0",
@@ -73,7 +74,15 @@
       "import/prefer-default-export": "off",
       "no-underscore-dangle": "off",
       "guard-for-in": "off",
-      "import/no-unresolved": ["error", { "ignore": ["^meteor/", "^/"] }],
+      "import/no-unresolved": [
+        "error",
+        {
+          "ignore": [
+            "^meteor/",
+            "^/"
+          ]
+        }
+      ],
       "no-restricted-syntax": "off",
       "max-len": [
         "error",


### PR DESCRIPTION
@santisiri after considering and partially trying out other ideas [1], I concluded the best way to fix the modal unresponsive React links in the mobile view was to use the package [`react-fastclick`](https://github.com/JakeSidSmith/react-fastclick). Looks like this is a somewhat common issue, and this solution seemed to be more appropriate. 

After testing it out it looks like the `react-fastclick` works fine. Thing is using the package brought my attention to what seems to be a slightly different bug. Modal renders fine and all links work correctly _except_ 'recover password'. After looking into, it seems to be related to the code logic to render and autoposition the modal. Let me elaborate on that, this is what the form for `ForgotPassword.jsx` is supposed to look like:

```javascript
  <form id="recover-password" name="forgot-password-form" onSubmit={this.handleSubmit}>
    <div className="w-clearfix login-field">
      <label htmlFor="name" className="login-label login-label-form">{TAPi18n.__('recovery-email')}</label>
      <img src="/images/mail-closed.png" className="login-icon" alt="mail-closed" />
      <input id="recovery-email" type="text" placeholder={TAPi18n.__('email-sample')} className="w-input login-input" />
      {warning}
    </div>
    <div type="submit" id="recovery-button" className="button login-button" onClick={this.handleSubmit}>
      <div>{TAPi18n.__('continue-password-recovery')}</div>
    </div>
  </form>
```

Behavior I see is: I click on 'recover password', modal renders for like a fraction of a second, then goes away (easier to visualize using Google Chrome Tools debugger). However if I add at least one more field input `<div>`:

```javascript
  <form id="recover-password" name="forgot-password-form" onSubmit={this.handleSubmit}>
    <div className="w-clearfix login-field">
      <label htmlFor="name" className="login-label login-label-form">{TAPi18n.__('recovery-email')}</label>
      <img src="/images/mail-closed.png" className="login-icon" alt="mail-closed" />
      <input id="recovery-email" type="text" placeholder={TAPi18n.__('email-sample')} className="w-input login-input" />
      {warning}
    </div>
    <div className="w-clearfix login-field">
      <label htmlFor="name" className="login-label login-label-form">TESTING, TO REMOVE</label>
      <img src="/images/mail-closed.png" className="login-icon" alt="mail-closed" />
      <input id="recovery-email" type="text" placeholder="TESING, TO REMOVE" className="w-input login-input" />
      {warning}
    </div>
    <div type="submit" id="recovery-button" className="button login-button" onClick={this.handleSubmit}>
      <div>{TAPi18n.__('continue-password-recovery')}</div>
    </div>
  </form>
```

The modal renders and does not go away. With the regular `ForgotPassword` form, modal height seems to not be correct and somewhere `modalPosition()` is getting invoked again and messing up the autoPosition.

So a few things: 

* Any insight on how to properly render the modal? Note that this is an issue for mobile only because the desktop view render the 'pointer-up' popup and not the same modal. 
* You think `subscribe.js` is the best place to `initReactFastclick();`?





---

[1] Other options included adding the `onTouchStart` event listener in every React component with an `onClick`listener. Not the most elegant solution in my opinion and, as a matter of fact, not even completely efficient because this brought up a series of double-firing onTouch-onClick mess.

Also looked into adding attributes conditionally but that seemed to bring up the same sort of issues mentioned above. 

Some resources I looked at: 

https://github.com/JedWatson/react-tappable/issues/41
https://github.com/facebook/react/issues/2055
https://stackoverflow.com/questions/40035230/how-to-conditionally-add-attributes-to-react-dom-element
https://github.com/facebook/react/issues/436#issuecomment-207624448

---

Addresses #208 
