### PR TITLE
Make raven use optional

### DIFF
--- a/imports/startup/client/raven.js
+++ b/imports/startup/client/raven.js
@@ -3,8 +3,10 @@ import { Meteor } from 'meteor/meteor';
 
 const ravenOptions = {};
 
-export const ravenLogger = new RavenLogger({
+const enabled = Meteor.settings.public.sentryPublicDSN && Meteor.settings.public.sentryPublicDSN.length > 0;
+
+export const ravenLogger = enabled ? new RavenLogger({
   publicDSN: Meteor.settings.public.sentryPublicDSN,
   shouldCatchConsoleError: true, // default true
   trackUser: true, // default false
-}, ravenOptions);
+}, ravenOptions) : { log: (error) => { console.log(error); } };


### PR DESCRIPTION
This PR makes the use of raven optional if we don't configure the sentry keys in `settings.json`, for instance, in our development space.

Without configuring sentry (and without this PR), we see all logs in console catched by sentry/flowkey-raven so it's more confuse to read the logs.

In summary, we'll use sentry in space where we cannot see the console logs (like in testing environments, in our users's browsers, production, etc) but not in development if we don't want to.