### PR TITLE
Added signup/signin and edit profile chimp tests

### DIFF
--- a/features/login.feature
+++ b/features/login.feature
@@ -1,0 +1,21 @@
+Feature: Signup/signin as a citizen
+  In order to share knowledge and initiate legal updates
+  As a citizen
+  I need to be able to signup and signin and to edit my profile
+
+  Background:
+    Given I am on the homepage
+
+  Scenario: A user can register and login
+    When I click in the user loggin button
+    And I click in the sign up link
+    And I register with some name, password and email
+    Then I should be registered
+    And I should be logged in
+    When I sign out
+    When I enter incorrect authentication information
+    Then I should see a user not found error
+    And I enter my email and password
+    Then I should be logged in
+    When I click in the user loggin button
+    Then I can edit my profile

--- a/features/step_definitions/browser-steps.js
+++ b/features/step_definitions/browser-steps.js
@@ -33,6 +33,14 @@ export default function () {
     getBrowser().keys(keys);
   });
 
+  this.When(/^I click in the user loggin button$/, () => {
+    widgets.loggedUserButton.click();
+  });
+
+  this.When(/^I click in the sign up link$/, () => {
+    clickOnElement('#signup');
+  });
+
   this.When(/^I trigger the floating action button$/, () => {
     widgets.fab.click();
   });

--- a/features/step_definitions/login-steps.js
+++ b/features/step_definitions/login-steps.js
@@ -1,0 +1,65 @@
+import { clickOnElement, getBrowser, typeInInput, randomUsername, randomPassword, randomEmail } from './support/utils';
+
+export default function () {
+  let userName;
+  let firstName;
+  let lastName;
+  let pass;
+  let email;
+
+  function login(badpass) {
+    getBrowser().waitForVisible('#signin-button', 5000);
+    typeInInput('signin-email', email);
+    typeInInput('signin-password', badpass ? randomPassword() : pass);
+    getBrowser().click('#signin-button');
+  }
+
+  this.When(/^I register with some name, password and email$/, function () {
+    getBrowser().waitForVisible('input[name="username-signup"]', 5000);
+    userName = randomUsername();
+    email = randomEmail();
+    pass = randomPassword();
+    typeInInput('username-signup', userName);
+    typeInInput('email-signup', email);
+    typeInInput('password-signup', pass);
+    typeInInput('mismatchPassword', pass);
+    clickOnElement('#signup-button');
+  });
+
+  this.Then(/^I should be registered$/, function () {
+    getBrowser().waitForVisible('#logout', 10000, true);
+  });
+
+
+  this.Then(/^I should be logged in$/, function () {
+    getBrowser().waitForVisible('#action', 10000, true);
+  });
+
+
+  this.When(/^I sign out$/, function () {
+    clickOnElement('#logout');
+  });
+
+  this.When(/^I enter my email and password$/, function () {
+    login();
+  });
+
+  this.Then(/^I can edit my profile$/, function () {
+    getBrowser().waitForVisible('#logout', 5000);
+    firstName = randomUsername();
+    lastName = randomUsername();
+    typeInInput('editFirstName', firstName);
+    typeInInput('editLastName', lastName);
+    getBrowser().click('#save-profile');
+    getBrowser().waitForText('.identity-label', `${firstName} ${lastName}`);
+    getBrowser().waitForText('.vote-available', '1,000 TOTAL VOTES');
+  });
+
+  this.When(/^I enter incorrect authentication information$/, function () {
+    login(true);
+  });
+
+  this.Then(/^I should see a user not found error$/, function () {
+    getBrowser().waitForText('.warning', 'User not found.');
+  });
+}

--- a/features/step_definitions/support/utils.js
+++ b/features/step_definitions/support/utils.js
@@ -268,6 +268,18 @@ export const typeInEditable = (element, text, submit) => {
   }
 };
 
+/**
+ * @param element
+ * @param {string} text
+ * @param {boolean} submit - Defaults to false. Hits Enter after the text when true.
+ */
+export const typeInInput = (elementId, text) => {
+  try {
+    getBrowser().setValue(`input[name="${elementId}"]`, text);
+  } catch (e) {
+    getBrowser().setValue(`#${elementId}`, text);
+  }
+};
 
 
 //// STRING UTILS //////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -318,9 +330,26 @@ export const castNum = (thing) => {
   return require('words-to-numbers').wordsToNumbers(thing);
 };
 
+// https://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript
+const makeid = (size) => {
+  let text = '';
+  const possible = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < size; i += 1) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+};
 
 
-//// ASSERTIONS UTILS //////////////////////////////////////////////////////////////////////////////////////////////////
+export const randomText = (n) => { return makeid(n); };
+
+export const randomUsername = () => { return makeid(7); };
+
+export const randomPassword = () => { return randomUsername(); };
+
+export const randomEmail = () => { return `${randomUsername()}@example.com`; };
+
+// // ASSERTIONS UTILS //////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
  * Returns whatever needles were not recursively found in haystack, or null.

--- a/features/step_definitions/support/widgets/user-logged-icon.js
+++ b/features/step_definitions/support/widgets/user-logged-icon.js
@@ -1,0 +1,14 @@
+/**
+ * Logged User  Button
+ * @type {Widget}
+ */
+class LoggedUserButton extends widgets.Base {
+  get selectors() {
+    return {
+      self: '#loggedUser',
+    };
+  }
+}
+
+widgets.LoggedUserButton = LoggedUserButton;
+widgets.loggedUserButton = new LoggedUserButton();


### PR DESCRIPTION
Some more chimp tests.

This is some basic sign-in/out/register and edit profile (something that should never fail in Production).

@domi41 I'm using many getBrowser().whatEver in `login-stepsj.js`, but I think it's more easy for others to start using chimp/cucumber/webdriver. Also, I thing we can try to use the register/login steps to avoid this bug #267.