### PR TITLE
Edit username validation logic to fix usernme update issue

### DIFF
--- a/imports/startup/both/modules/User.js
+++ b/imports/startup/both/modules/User.js
@@ -22,14 +22,14 @@ const _validateUsername = (username) => {
   const regexp = /^[a-zA-Z0-9\-_]{0,40}$/;
 
   // Set whether username format is valid or not
-  usernameValidationObject.valid = !regexp.test(username);
+  usernameValidationObject.valid = regexp.test(username);
 
   // Only if username is valid, check whether it exists already
-  if (regexp.test(username)) {
+  if (usernameValidationObject.valid) {
     Meteor.call('getUser', username, function (error, result) {
       if (result) {
         if (Meteor.user()) {
-          if (result.username !== Meteor.user().username) {
+          if (result.username !== Meteor.user().username && result.username !== '' ) {
             Session.set('queryUsernameStatus', 'DUPLICATE');
           } else {
             Session.set('queryUsernameStatus', 'SINGULAR');
@@ -111,7 +111,7 @@ const _getAnonObject = (signatureMode) => {
 const _validateUser = (data) => {
   const validUsername = _validateUsername(data.username);
 
-  const val = !validUsername.valid + validateEmail(data.email) + _validatePassword(data.password) + _validatePasswordMatch(data.password, data.mismatchPassword);
+  const val = validUsername.valid + validateEmail(data.email) + _validatePassword(data.password) + _validatePasswordMatch(data.password, data.mismatchPassword);
 
   if (val >= 4) { return true; } return false;
 };

--- a/imports/ui/templates/components/identity/login/profile/profileEditor.js
+++ b/imports/ui/templates/components/identity/login/profile/profileEditor.js
@@ -66,7 +66,7 @@ Template.profileEditor.events({
   },
   'blur #editUserName'() {
     const validation = validateUsername(document.getElementById('editUserName').value);
-    if (validation.valid) {
+    if (!validation.valid) {
       Session.set('noUsernameFound', true);
       Session.set('queryUsernameStatus', '');
     } else {
@@ -84,7 +84,7 @@ Template.profileEditor.events({
     const validation = validateUsername(document.getElementById('editUserName').value);
     if (document.getElementById('editFirstName').value === '') {
       Session.set('noNameFound', true);
-    } else if (validation.valid || document.getElementById('editUserName').value === '') {
+    } else if (!validation.valid || document.getElementById('editUserName').value === '') {
       Session.set('noUsernameFound', true);
       Session.set('queryUsernameStatus', '');
     } else if (Session.get('queryUsernameStatus') === 'SINGULAR') {

--- a/imports/ui/templates/components/identity/signup/Signup.jsx
+++ b/imports/ui/templates/components/identity/signup/Signup.jsx
@@ -43,7 +43,7 @@ export default class Signup extends Component {
       switch (event.target.name) {
         case 'username-signup':
           const validUsername = validateUsername(event.target.value);
-          this.setState({ invalidUsername: validUsername.valid });
+          this.setState({ invalidUsername: !validUsername.valid });
           this.setState({ repeatedUsername: validUsername.repeated });
           break;
         case 'email-signup':


### PR DESCRIPTION
Found some inconsistencies in the username validation logic that were preventing a username update to go through, both for users who signed up via email or Metamask. Tested in local environment: 

- edit username for a user signed up via Metamask
- edit username for a user signed up via email
- edit required first name value without updating username, and viceversa
- have warning popups appear only when appropriate 

Let's check if I'm missing something else.

Closes #374 
