### PR TITLE
Remove first name as required in profile editor

### DIFF
--- a/imports/ui/templates/components/identity/login/profile/profileEditor.html
+++ b/imports/ui/templates/components/identity/login/profile/profileEditor.html
@@ -13,11 +13,6 @@
           <input type="text" id="editFirstName" placeholder="Satoshi" autocomplete="false" class="w-input login-input login-input-split login-input-split-right" value="{{firstName}}">
           <input type="text" id="editLastName" placeholder="Nakamoto" autocomplete="false" class="w-input login-input login-input-split login-input-split-right" value="{{lastName}}">
         </div>
-        {{#if noNameFound}}
-          <div class="extra extra-warning">
-            {{> warning label="missing-name"}}
-          </div>
-        {{/if}}
         <div class="login-field">
           <label for="name" class="login-label login-label-form">
             {{_ "digital-name"}}

--- a/imports/ui/templates/components/identity/login/profile/profileEditor.js
+++ b/imports/ui/templates/components/identity/login/profile/profileEditor.js
@@ -13,7 +13,6 @@ import '../../../../widgets/suggest/suggest.js';
 
 Template.profileEditor.rendered = function rendered() {
   Session.set('showNations', false);
-  Session.set('noNameFound', false);
   Session.set('noUsernameFound', false);
 };
 
@@ -38,9 +37,6 @@ Template.profileEditor.helpers({
   },
   showNations() {
     return Session.get('showNations');
-  },
-  noNameFound() {
-    return Session.get('noNameFound');
   },
   noUsernameFound() {
     return Session.get('noUsernameFound');
@@ -82,13 +78,10 @@ Template.profileEditor.events({
   },
   'click #save-profile'() {
     const validation = validateUsername(document.getElementById('editUserName').value);
-    if (document.getElementById('editFirstName').value === '') {
-      Session.set('noNameFound', true);
-    } else if (!validation.valid || document.getElementById('editUserName').value === '') {
+    if (!validation.valid || document.getElementById('editUserName').value === '') {
       Session.set('noUsernameFound', true);
       Session.set('queryUsernameStatus', '');
     } else if (Session.get('queryUsernameStatus') === 'SINGULAR') {
-      Session.set('noNameFound', false);
       Session.set('noUsernameFound', false);
 
       // Save


### PR DESCRIPTION
This makes username the only required field in the `profileEditor` now.

Closes #378 