### PR TITLE
handle privacy mode metamask update

### DIFF
--- a/imports/startup/both/modules/metamask.js
+++ b/imports/startup/both/modules/metamask.js
@@ -45,11 +45,9 @@ const _web3 = (activateModal) => {
     return false;
   }
   if (!web3) {
-    // We don't know window.web3 version, so we use our own instance of web3
-    // with provider given by window.web3
-    web3 = new Web3(window.web3.currentProvider);
+    web3 = new Web3(window.ethereum);
   }
-  
+
   web3.eth.getCoinbase().then(function (coinbase) {
     if (!coinbase) {
       if (activateModal) {
@@ -203,10 +201,12 @@ if (Meteor.isClient) {
   const loginWithMetamask = () => {
     if (_web3(true)) {
       const nonce = Math.floor(Math.random() * 10000);
-      // const publicAddress = web3.eth.getCoinbase.toLowerCase();
+
       let publicAddress;
 
-      web3.eth.getCoinbase().then(function (coinbaseAddress) {
+      window.ethereum.enable().then(function () {
+        return web3.eth.getCoinbase();
+      }).then(function (coinbaseAddress) {
         publicAddress = coinbaseAddress.toLowerCase();
         return handleSignMessage(publicAddress, nonce);
       }).then(function (signature) {


### PR DESCRIPTION
Looks like this is what's needed to adjust to [Metamask's privacy mode](https://medium.com/metamask/introducing-privacy-mode-42549d4870fa) update, mainly [using `etherum.enable()`](https://medium.com/metamask/eip-1102-preparing-your-dapp-5027b2c9ed76). I suggest we test further before merging, seems stable from my machine but I understand [rollout is still happening](https://twitter.com/danfinlay/status/1059930381007282176). 

Also not sure where Metamask is reading app title from but could be prettier:

<img width="435" alt="screen shot 2018-11-08 at 3 41 57 pm" src="https://user-images.githubusercontent.com/4752599/48226575-1dc29800-e36e-11e8-8cb0-49fb975c9016.png">



Other reference - https://github.com/MetaMask/metamask-extension/pull/4703