### PR TITLE
update blockstack.js to 18.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.46.tgz",
       "integrity": "sha512-/3a3USMKk54BEHhDgY8rtxtaQOs4bp4aQwo6SDtdwmrXmgSgEusWuXNX5oIs/nwzmTD9o8wz2EyAjA+uHDMmJA==",
       "requires": {
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.5.3",
+        "regenerator-runtime": "^0.11.1"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -53,8 +53,8 @@
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
+        "extend": "~3.0.0",
+        "semver": "~5.0.1"
       },
       "dependencies": {
         "semver": {
@@ -70,8 +70,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "ajv-keywords": {
@@ -109,8 +109,8 @@
       "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "aproba": {
@@ -124,14 +124,14 @@
       "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "async": "2.6.0",
-        "buffer-crc32": "0.2.13",
-        "glob": "7.1.2",
-        "lodash": "4.17.10",
-        "readable-stream": "2.3.5",
-        "tar-stream": "1.5.2",
-        "zip-stream": "1.2.0"
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.2.0"
       },
       "dependencies": {
         "async": {
@@ -140,7 +140,7 @@
           "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.14.0"
           }
         },
         "balanced-match": {
@@ -155,7 +155,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -165,12 +165,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -179,7 +179,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "process-nextick-args": {
@@ -194,13 +194,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -209,7 +209,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -220,12 +220,12 @@
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lazystream": "1.0.0",
-        "lodash": "4.17.10",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.5"
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -240,7 +240,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -250,12 +250,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -264,7 +264,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "process-nextick-args": {
@@ -279,13 +279,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -294,7 +294,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -304,8 +304,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       },
       "dependencies": {
         "core-util-is": {
@@ -333,13 +333,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -347,7 +347,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "util-deprecate": {
@@ -363,7 +363,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -372,7 +372,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -387,7 +387,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -408,8 +408,8 @@
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "arrify": {
@@ -433,9 +433,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert-plus": {
@@ -451,7 +451,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
@@ -476,12 +476,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000777",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "browserslist": "^1.7.6",
+        "caniuse-db": "^1.0.30000634",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^5.2.16",
+        "postcss-value-parser": "^3.2.3"
       }
     },
     "aws-sign2": {
@@ -511,25 +511,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -550,9 +550,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-register": {
@@ -561,13 +561,13 @@
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "dev": true,
           "requires": {
-            "babel-core": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.5",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.4",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
           }
         },
         "balanced-match": {
@@ -582,7 +582,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -592,11 +592,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "concat-map": {
@@ -632,7 +632,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "js-tokens": {
@@ -653,7 +653,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -689,7 +689,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -706,10 +706,10 @@
       "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
+        "babel-code-frame": "^6.22.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.17.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -730,9 +730,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "chalk": {
@@ -741,11 +741,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "escape-string-regexp": {
@@ -766,7 +766,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "js-tokens": {
@@ -781,7 +781,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -798,14 +798,14 @@
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.6",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "lodash": {
@@ -822,9 +822,9 @@
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -833,9 +833,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -844,10 +844,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -856,10 +856,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -868,9 +868,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-explode-class": {
@@ -879,10 +879,10 @@
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true,
       "requires": {
-        "babel-helper-bindify-decorators": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -891,11 +891,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -904,8 +904,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -914,8 +914,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -924,8 +924,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -934,9 +934,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -945,11 +945,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -958,12 +958,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -972,8 +972,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -982,7 +982,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -991,7 +991,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -1048,9 +1048,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -1059,9 +1059,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -1070,10 +1070,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -1082,11 +1082,11 @@
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-class": "6.24.1",
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1095,7 +1095,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1104,7 +1104,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1113,11 +1113,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1126,15 +1126,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1143,8 +1143,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1153,7 +1153,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1162,8 +1162,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1172,7 +1172,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1181,9 +1181,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1192,7 +1192,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1201,9 +1201,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1212,10 +1212,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1224,9 +1224,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1235,9 +1235,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1246,8 +1246,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1256,12 +1256,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1270,8 +1270,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1280,7 +1280,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1289,9 +1289,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1300,7 +1300,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1309,7 +1309,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1318,9 +1318,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1329,9 +1329,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1340,8 +1340,8 @@
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1350,7 +1350,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -1359,7 +1359,7 @@
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1368,8 +1368,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
@@ -1378,9 +1378,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       }
     },
     "babel-preset-es2015": {
@@ -1389,30 +1389,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -1421,10 +1421,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -1433,11 +1433,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       }
     },
     "babel-register": {
@@ -1446,13 +1446,13 @@
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "core-js": "^2.4.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.2"
       },
       "dependencies": {
         "lodash": {
@@ -1483,8 +1483,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "core-js": {
@@ -1505,11 +1505,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
@@ -1526,15 +1526,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1555,9 +1555,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "chalk": {
@@ -1566,11 +1566,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "debug": {
@@ -1600,7 +1600,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "js-tokens": {
@@ -1627,7 +1627,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1644,10 +1644,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
         "esutils": {
@@ -1680,7 +1680,7 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
       "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "base64url": {
@@ -1710,7 +1710,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bcryptjs": {
@@ -1744,12 +1744,12 @@
       "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.2.tgz",
       "integrity": "sha512-kedLYj8yvYzND+EfzeoMSlGiN7ImiRBF/MClJSZPkMfcU+OQO7ZpL5L/Yg+TunebBZIHhunstiQF//KLKSF5rg==",
       "requires": {
-        "bs58check": "2.1.2",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "tiny-secp256k1": "1.0.1",
-        "typeforce": "1.16.0",
-        "wif": "2.0.6"
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
       }
     },
     "bip39": {
@@ -1757,11 +1757,11 @@
       "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.5.0.tgz",
       "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
       "requires": {
-        "create-hash": "1.2.0",
-        "pbkdf2": "3.0.17",
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1",
-        "unorm": "1.4.1"
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "unorm": "^1.3.3"
       }
     },
     "bip66": {
@@ -1769,7 +1769,7 @@
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "bitcoin-ops": {
@@ -1782,21 +1782,21 @@
       "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.2.tgz",
       "integrity": "sha512-Y6AW91WPDoDQQLy4FejVoH4NvENqvMy+Q/8mnakEzckG1NXiLo0VgnEZyuvZb6lkhE2+YxzTCgpqzbnerOSpEg==",
       "requires": {
-        "bech32": "1.1.3",
-        "bip32": "1.0.2",
-        "bip66": "1.1.5",
-        "bitcoin-ops": "1.4.1",
-        "bs58check": "2.1.2",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "merkle-lib": "2.0.10",
-        "pushdata-bitcoin": "1.0.1",
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1",
-        "tiny-secp256k1": "1.0.1",
-        "typeforce": "1.16.0",
-        "varuint-bitcoin": "1.1.0",
-        "wif": "2.0.6"
+        "bech32": "^1.1.2",
+        "bip32": "^1.0.0",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.4.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.1",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
       }
     },
     "bl": {
@@ -1805,8 +1805,8 @@
       "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5",
-        "safe-buffer": "5.1.1"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -1821,13 +1821,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1836,7 +1836,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1846,7 +1846,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       },
       "dependencies": {
         "inherits": {
@@ -1857,34 +1857,34 @@
       }
     },
     "blockstack": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-18.1.0.tgz",
-      "integrity": "sha512-7N5Bea3dV4p9/g+2g318qoieEvkPT34if1pMFxcqIbpb3t+rBVzSMxjU6JWL1e5VyYWZJdrtHgw7J+uWZQNTew==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/blockstack/-/blockstack-18.2.1.tgz",
+      "integrity": "sha512-hcJdNhltNSRZg6iouSauWOzKpVnfC1NFIMBhC9sZjaIFCPIojDrgvRcgoh3AEy8LMkj1krr26AKAOhnRcQJmng==",
       "requires": {
-        "ajv": "4.11.8",
-        "babel-runtime": "6.26.0",
-        "bigi": "1.4.2",
-        "bip32": "1.0.2",
-        "bip39": "2.5.0",
-        "bitcoinjs-lib": "4.0.2",
-        "cheerio": "0.22.0",
-        "cross-fetch": "2.2.3",
+        "ajv": "^4.11.5",
+        "babel-runtime": "^6.26.0",
+        "bigi": "^1.4.2",
+        "bip32": "^1.0.2",
+        "bip39": "^2.5.0",
+        "bitcoinjs-lib": "^4",
+        "cheerio": "^0.22.0",
+        "cross-fetch": "^2.2.2",
         "custom-protocol-detection-blockstack": "1.1.4",
-        "ecurve": "1.0.6",
-        "elliptic": "6.4.0",
-        "es6-promise": "4.2.4",
-        "form-data": "2.3.3",
-        "jsontokens": "0.7.8",
-        "promise": "7.3.1",
-        "query-string": "4.3.4",
-        "request": "2.88.0",
-        "ripemd160": "2.0.2",
-        "schema-inspector": "1.6.8",
-        "sprintf-js": "1.0.3",
-        "triplesec": "3.0.27",
-        "uuid": "3.3.2",
-        "validator": "7.2.0",
-        "zone-file": "0.2.3"
+        "ecurve": "^1.0.6",
+        "elliptic": "^6.4.0",
+        "es6-promise": "^4.2.4",
+        "form-data": "^2.3.2",
+        "jsontokens": "^0.7.8",
+        "promise": "^7.1.1",
+        "query-string": "^4.3.2",
+        "request": "^2.87.0",
+        "ripemd160": "^2.0.1",
+        "schema-inspector": "^1.6.4",
+        "sprintf-js": "^1.0.3",
+        "triplesec": "^3.0.26",
+        "uuid": "^3.2.1",
+        "validator": "^7.0.0",
+        "zone-file": "^0.2.2"
       },
       "dependencies": {
         "aws4": {
@@ -1893,16 +1893,16 @@
           "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
         "base64url": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.0.tgz",
-          "integrity": "sha512-LIVmqIrIWuiqTvn4RzcrwCOuHo2DD6tKmKBPXXlr4p4n4l6BZBkwFTIa3zu1XkX5MbZgro4a6BvPi+n2Mns5Gg=="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+          "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
         },
         "combined-stream": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
           "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "extend": {
@@ -1920,9 +1920,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.7",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
           }
         },
         "har-validator": {
@@ -1930,19 +1930,19 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
           "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
           "requires": {
-            "ajv": "6.5.5",
-            "har-schema": "2.0.0"
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
           },
           "dependencies": {
             "ajv": {
-              "version": "6.5.5",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-              "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+              "version": "6.6.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+              "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
               "requires": {
-                "fast-deep-equal": "2.0.1",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.4.1",
-                "uri-js": "4.2.2"
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
               }
             }
           }
@@ -1957,11 +1957,11 @@
           "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-0.7.8.tgz",
           "integrity": "sha512-vTZ06cDSDoFeXJUnZNFHsh8aP+L3Xz5Ke7XPb6nyT3n5wb9uxyq4TE8gUl0H4hmzSe/YIrDi+mneuHIh37AMiA==",
           "requires": {
-            "asn1.js": "4.10.1",
-            "base64url": "3.0.0",
-            "elliptic": "6.4.0",
-            "key-encoder": "1.1.6",
-            "validator": "7.2.0"
+            "asn1.js": "^4.9.1",
+            "base64url": "^3.0.0",
+            "elliptic": "^6.3.2",
+            "key-encoder": "^1.1.6",
+            "validator": "^7.0.0"
           }
         },
         "mime-db": {
@@ -1984,26 +1984,26 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
           "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.7",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.3",
-            "har-validator": "5.1.3",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.21",
-            "oauth-sign": "0.9.0",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "tough-cookie": "2.4.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.3.2"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
           },
           "dependencies": {
             "mime-types": {
@@ -2011,7 +2011,7 @@
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
               "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
               "requires": {
-                "mime-db": "1.37.0"
+                "mime-db": "~1.37.0"
               }
             }
           }
@@ -2026,8 +2026,8 @@
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
         },
         "uuid": {
@@ -2058,7 +2058,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       },
       "dependencies": {
         "hoek": {
@@ -2083,9 +2083,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -2104,8 +2104,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "requires": {
-        "caniuse-db": "1.0.30000777",
-        "electron-to-chromium": "1.3.27"
+        "caniuse-db": "^1.0.30000639",
+        "electron-to-chromium": "^1.2.7"
       }
     },
     "bs58": {
@@ -2113,7 +2113,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "requires": {
-        "base-x": "3.0.5"
+        "base-x": "^3.0.2"
       }
     },
     "bs58check": {
@@ -2121,9 +2121,9 @@
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
       "requires": {
-        "bs58": "4.0.1",
-        "create-hash": "1.2.0",
-        "safe-buffer": "5.1.2"
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -2151,7 +2151,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -2166,8 +2166,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "caniuse-db": {
@@ -2186,12 +2186,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chai-as-promised": {
@@ -2200,7 +2200,7 @@
       "integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
       "dev": true,
       "requires": {
-        "check-error": "1.0.2"
+        "check-error": "^1.0.2"
       }
     },
     "chai-string": {
@@ -2241,25 +2241,25 @@
     },
     "cheerio": {
       "version": "0.22.0",
-      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.2",
-        "htmlparser2": "3.10.0",
-        "lodash.assignin": "4.2.0",
-        "lodash.bind": "4.2.1",
-        "lodash.defaults": "4.2.0",
-        "lodash.filter": "4.6.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.foreach": "4.5.0",
-        "lodash.map": "4.6.0",
-        "lodash.merge": "4.6.1",
-        "lodash.pick": "4.4.0",
-        "lodash.reduce": "4.6.0",
-        "lodash.reject": "4.6.0",
-        "lodash.some": "4.6.0"
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash.assignin": "^4.0.9",
+        "lodash.bind": "^4.1.4",
+        "lodash.defaults": "^4.0.1",
+        "lodash.filter": "^4.4.0",
+        "lodash.flatten": "^4.2.0",
+        "lodash.foreach": "^4.3.0",
+        "lodash.map": "^4.4.0",
+        "lodash.merge": "^4.4.0",
+        "lodash.pick": "^4.2.1",
+        "lodash.reduce": "^4.4.0",
+        "lodash.reject": "^4.4.0",
+        "lodash.some": "^4.4.0"
       }
     },
     "child-process-debug": {
@@ -2274,44 +2274,44 @@
       "integrity": "sha1-6hIbzfJsidV/jvNBlUDPPCeaPMU=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "babel-core": "6.26.0",
-        "babel-plugin-transform-runtime": "6.23.0",
-        "babel-polyfill": "6.26.0",
-        "babel-preset-es2015": "6.24.1",
-        "babel-preset-stage-2": "6.24.1",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "bluebird": "3.5.1",
-        "chai": "4.1.2",
-        "chai-as-promised": "6.0.0",
+        "async": "~0.9.0",
+        "babel-core": "^6.4.5",
+        "babel-plugin-transform-runtime": "6.x.x",
+        "babel-polyfill": "^6.3.14",
+        "babel-preset-es2015": "6.x.x",
+        "babel-preset-stage-2": "6.x.x",
+        "babel-register": "^6.4.3",
+        "babel-runtime": "6.x.x",
+        "bluebird": "^3.4.7",
+        "chai": "~4.1.2",
+        "chai-as-promised": "^6.0.0",
         "child-process-debug": "0.0.7",
-        "chokidar": "1.6.1",
-        "chromedriver": "2.37.0",
+        "chokidar": "~1.6.0",
+        "chromedriver": "^2.35",
         "colors": "1.1.2",
-        "commander": "2.15.1",
+        "commander": "^2.9.0",
         "cucumber": "github:xolvio/cucumber-js#cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
-        "deep-extend": "0.4.2",
-        "exit": "0.1.2",
-        "fibers": "1.0.15",
-        "freeport": "1.0.5",
-        "fs-extra": "1.0.0",
+        "deep-extend": "^0.4.1",
+        "exit": "^0.1.2",
+        "fibers": "^1.0.14",
+        "freeport": "~1.0.5",
+        "fs-extra": "^1.0.0",
         "glob": "github:lucetius/node-glob#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
         "hapi": "8.8.0",
-        "jasmine": "2.99.0",
-        "loglevel": "1.4.1",
-        "minimist": "1.2.0",
-        "mocha": "4.1.0",
+        "jasmine": "^2.4.1",
+        "loglevel": "~1.4.0",
+        "minimist": "~1.2.0",
+        "mocha": "^4.1.0",
         "phantomjs-prebuilt": "2.1.15",
-        "progress": "1.1.8",
-        "request": "2.83.0",
+        "progress": "^1.1.8",
+        "request": "^2.79.0",
         "requestretry": "1.5.0",
-        "saucelabs": "1.4.0",
-        "selenium-standalone": "6.13.0",
-        "underscore": "1.8.3",
-        "xolvio-ddp": "0.12.3",
-        "xolvio-jasmine-expect": "1.1.0",
-        "xolvio-sync-webdriverio": "9.0.1"
+        "saucelabs": "^1.3.0",
+        "selenium-standalone": "^6.12.0",
+        "underscore": "~1.8.3",
+        "xolvio-ddp": "^0.12.0",
+        "xolvio-jasmine-expect": "^1.0.0",
+        "xolvio-sync-webdriverio": "^9.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2344,7 +2344,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -2353,7 +2353,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2363,7 +2363,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "es6-promise": {
@@ -2378,21 +2378,22 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "glob": {
           "version": "github:lucetius/node-glob#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
+          "from": "glob@github:lucetius/node-glob#51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
             "once": "1.3.0",
-            "path-is-absolute": "1.0.1"
+            "path-is-absolute": "^1.0.0"
           }
         },
         "har-schema": {
@@ -2407,8 +2408,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "hawk": {
@@ -2417,10 +2418,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -2435,9 +2436,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "minimatch": {
@@ -2446,7 +2447,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2473,15 +2474,15 @@
           "integrity": "sha1-IPhugtM0nFBZF1J3RbekEeCLOQM=",
           "dev": true,
           "requires": {
-            "es6-promise": "4.0.5",
-            "extract-zip": "1.6.6",
-            "fs-extra": "1.0.0",
-            "hasha": "2.2.0",
-            "kew": "0.7.0",
-            "progress": "1.1.8",
-            "request": "2.81.0",
-            "request-progress": "2.0.1",
-            "which": "1.2.14"
+            "es6-promise": "~4.0.3",
+            "extract-zip": "~1.6.5",
+            "fs-extra": "~1.0.0",
+            "hasha": "~2.2.0",
+            "kew": "~0.7.0",
+            "progress": "~1.1.8",
+            "request": "~2.81.0",
+            "request-progress": "~2.0.1",
+            "which": "~1.2.10"
           },
           "dependencies": {
             "request": {
@@ -2490,28 +2491,28 @@
               "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "dev": true,
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
               }
             }
           }
@@ -2528,7 +2529,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         }
       }
@@ -2539,15 +2540,15 @@
       "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "chromedriver": {
@@ -2556,11 +2557,11 @@
       "integrity": "sha1-54Z8gjb2u4kCRze7/8mksz3tZYs=",
       "dev": true,
       "requires": {
-        "del": "3.0.0",
-        "extract-zip": "1.6.6",
-        "kew": "0.7.0",
-        "mkdirp": "0.5.1",
-        "request": "2.83.0"
+        "del": "^3.0.0",
+        "extract-zip": "^1.6.5",
+        "kew": "^0.7.0",
+        "mkdirp": "^0.5.1",
+        "request": "^2.83.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -2575,7 +2576,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2585,12 +2586,12 @@
           "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
           "dev": true,
           "requires": {
-            "globby": "6.1.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "p-map": "1.2.0",
-            "pify": "3.0.0",
-            "rimraf": "2.6.1"
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "glob": {
@@ -2599,12 +2600,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -2613,11 +2614,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -2634,7 +2635,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "object-assign": {
@@ -2656,8 +2657,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -2672,7 +2673,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-table": {
@@ -2720,7 +2721,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -2740,7 +2741,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -2755,10 +2756,10 @@
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "crc32-stream": "2.0.0",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.5"
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -2773,13 +2774,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2788,7 +2789,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2848,8 +2849,8 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "3.5.0",
-        "readable-stream": "2.3.5"
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -2864,13 +2865,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2879,34 +2880,34 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.5",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "create-react-class": {
@@ -2914,9 +2915,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
       "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -2937,12 +2938,12 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
         },
         "whatwg-fetch": {
           "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
           "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         }
       }
@@ -2953,11 +2954,11 @@
       "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.4",
-        "path-key": "2.0.1",
-        "semver": "5.5.0",
-        "shebang-command": "1.2.0",
-        "which": "1.2.14"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       },
       "dependencies": {
         "semver": {
@@ -2973,7 +2974,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -2981,7 +2982,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           },
           "dependencies": {
             "hoek": {
@@ -2999,10 +3000,10 @@
       "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "source-map": "0.1.43",
-        "source-map-resolve": "0.3.1",
-        "urix": "0.1.0"
+        "inherits": "^2.0.1",
+        "source-map": "^0.1.38",
+        "source-map-resolve": "^0.3.0",
+        "urix": "^0.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -3011,7 +3012,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -3022,18 +3023,18 @@
       "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
       "dev": true,
       "requires": {
-        "css": "2.2.1"
+        "css": "^2.0.0"
       }
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.2",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.2"
+        "nth-check": "~1.0.1"
       }
     },
     "css-value": {
@@ -3055,23 +3056,24 @@
     },
     "cucumber": {
       "version": "github:xolvio/cucumber-js#cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
+      "from": "cucumber@github:xolvio/cucumber-js#cf953cb5b5de30dbcc279f59e4ebff3aa040071c",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "cli-table": "0.3.1",
-        "co": "4.6.0",
-        "colors": "1.1.2",
-        "commander": "2.15.1",
-        "duration": "0.2.0",
-        "fibers": "1.0.15",
+        "camel-case": "^3.0.0",
+        "cli-table": "^0.3.1",
+        "co": "^4.6.0",
+        "colors": "^1.1.2",
+        "commander": "^2.9.0",
+        "duration": "^0.2.0",
+        "fibers": "^1.0.7",
         "figures": "1.7.0",
         "gherkin": "4.0.0",
-        "glob": "7.1.2",
-        "is-generator": "1.0.3",
-        "lodash": "4.17.10",
-        "meteor-promise": "0.8.6",
-        "stack-chain": "1.3.7",
-        "stacktrace-js": "1.3.1"
+        "glob": "^7.0.0",
+        "is-generator": "^1.0.2",
+        "lodash": "^4.0.0",
+        "meteor-promise": "^0.8.0",
+        "stack-chain": "^1.3.5",
+        "stacktrace-js": "^1.3.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -3140,7 +3142,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "ddp-ejson": {
@@ -3173,7 +3175,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -3199,8 +3201,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "del": {
@@ -3209,13 +3211,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -3233,7 +3235,7 @@
       "resolved": "https://registry.npmjs.org/deref/-/deref-0.6.4.tgz",
       "integrity": "sha1-vVqW1F2+0wEbuBvfaN31S+jhvU4=",
       "requires": {
-        "deep-extend": "0.4.2"
+        "deep-extend": "^0.4.0"
       }
     },
     "detect-indent": {
@@ -3242,7 +3244,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "diff": {
@@ -3262,8 +3264,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       },
       "dependencies": {
         "esutils": {
@@ -3285,28 +3287,28 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.2"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
     },
     "domelementtype": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
-      "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domhandler": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
-        "domelementtype": "1.2.1"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -3314,8 +3316,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.2.1"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "duration": {
@@ -3324,8 +3326,8 @@
       "integrity": "sha1-X5xN+q//ZV3phhEu/iXFl43YUUY=",
       "dev": true,
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.42"
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.2"
       },
       "dependencies": {
         "d": {
@@ -3334,7 +3336,7 @@
           "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.42"
+            "es5-ext": "~0.10.2"
           }
         },
         "es5-ext": {
@@ -3343,9 +3345,9 @@
           "integrity": "sha1-jAfdM68E1dzRMQtc7xO+pjqJuo0=",
           "dev": true,
           "requires": {
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.1",
-            "next-tick": "1.0.0"
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.1",
+            "next-tick": "1"
           },
           "dependencies": {
             "next-tick": {
@@ -3362,9 +3364,9 @@
           "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
           "dev": true,
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.42",
-            "es6-symbol": "3.1.1"
+            "d": "1",
+            "es5-ext": "^0.10.35",
+            "es6-symbol": "^3.1.1"
           },
           "dependencies": {
             "d": {
@@ -3373,7 +3375,7 @@
               "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
               "dev": true,
               "requires": {
-                "es5-ext": "0.10.42"
+                "es5-ext": "^0.10.9"
               }
             }
           }
@@ -3384,8 +3386,8 @@
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "dev": true,
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.42"
+            "d": "1",
+            "es5-ext": "~0.10.14"
           },
           "dependencies": {
             "d": {
@@ -3394,7 +3396,7 @@
               "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
               "dev": true,
               "requires": {
-                "es5-ext": "0.10.42"
+                "es5-ext": "^0.10.9"
               }
             }
           }
@@ -3407,7 +3409,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecurve": {
@@ -3415,8 +3417,8 @@
       "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
       "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
       "requires": {
-        "bigi": "1.4.2",
-        "safe-buffer": "5.1.1"
+        "bigi": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "ejs": {
@@ -3435,13 +3437,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "encoding": {
@@ -3449,7 +3451,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -3458,7 +3460,7 @@
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "entities": {
@@ -3472,7 +3474,7 @@
       "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
       "dev": true,
       "requires": {
-        "stackframe": "0.3.1"
+        "stackframe": "^0.3.1"
       }
     },
     "es-abstract": {
@@ -3481,11 +3483,11 @@
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3494,9 +3496,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
@@ -3598,41 +3600,41 @@
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.16.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.5.2",
-        "debug": "2.3.2",
-        "doctrine": "2.0.0",
-        "escope": "3.6.0",
-        "espree": "3.5.0",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.1",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.1",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.1",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.5.2",
+        "debug": "^2.1.1",
+        "doctrine": "^2.0.0",
+        "escope": "^3.6.0",
+        "espree": "^3.4.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.14.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -3641,8 +3643,8 @@
           "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "globals": {
@@ -3657,7 +3659,7 @@
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "^1.0.0"
           }
         }
       }
@@ -3668,7 +3670,7 @@
       "integrity": "sha1-oJMO14kegk4bPkNs35dUyBWikgw=",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "7.2.0"
+        "eslint-config-airbnb-base": "^7.2.0"
       }
     },
     "eslint-config-airbnb-base": {
@@ -3683,8 +3685,8 @@
       "integrity": "sha1-40ulNL+ZVCDrTNIjMC56WWfu5Tk=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.0",
-        "resolve": "1.1.7"
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.6"
       }
     },
     "eslint-import-resolver-node": {
@@ -3693,9 +3695,9 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "2.3.2",
-        "object-assign": "4.1.0",
-        "resolve": "1.1.7"
+        "debug": "^2.2.0",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.6"
       }
     },
     "eslint-plugin-import": {
@@ -3704,22 +3706,22 @@
       "integrity": "sha1-svoH68xTUE0PKkR3WC7Iv/GHG58=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.3.2",
-        "doctrine": "1.3.0",
-        "es6-map": "0.1.4",
-        "es6-set": "0.1.4",
-        "eslint-import-resolver-node": "0.2.3",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "lodash.endswith": "4.2.1",
-        "lodash.find": "4.6.0",
-        "lodash.findindex": "4.6.0",
-        "minimatch": "3.0.3",
-        "object-assign": "4.1.0",
-        "pkg-dir": "1.0.0",
-        "pkg-up": "1.0.0"
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.2.0",
+        "doctrine": "1.3.x",
+        "es6-map": "^0.1.3",
+        "es6-set": "^0.1.4",
+        "eslint-import-resolver-node": "^0.2.0",
+        "has": "^1.0.1",
+        "lodash.cond": "^4.3.0",
+        "lodash.endswith": "^4.0.1",
+        "lodash.find": "^4.3.0",
+        "lodash.findindex": "^4.3.0",
+        "minimatch": "^3.0.3",
+        "object-assign": "^4.0.1",
+        "pkg-dir": "^1.0.0",
+        "pkg-up": "^1.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -3728,8 +3730,8 @@
           "integrity": "sha1-E+dWgrVVGEJCdvfBc3g0Vu+RPSY=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         }
       }
@@ -3740,9 +3742,9 @@
       "integrity": "sha1-TjXLcbin23AqxBXIBuuOjZ6mxl0=",
       "dev": true,
       "requires": {
-        "damerau-levenshtein": "1.0.4",
-        "jsx-ast-utils": "1.4.1",
-        "object-assign": "4.1.1"
+        "damerau-levenshtein": "^1.0.0",
+        "jsx-ast-utils": "^1.0.0",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -3774,13 +3776,13 @@
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "dev": true,
           "requires": {
-            "babel-core": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.5",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.10",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
           }
         },
         "invariant": {
@@ -3789,7 +3791,7 @@
           "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -3800,11 +3802,11 @@
       "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
       "requires": {
-        "array.prototype.find": "2.0.4",
-        "doctrine": "1.5.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "1.4.1",
-        "object.assign": "4.0.4"
+        "array.prototype.find": "^2.0.1",
+        "doctrine": "^1.2.2",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^1.3.4",
+        "object.assign": "^4.0.4"
       }
     },
     "espree": {
@@ -3813,8 +3815,8 @@
       "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.1.1",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -3829,7 +3831,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -3890,7 +3892,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -3899,7 +3901,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "extend": {
@@ -3913,9 +3915,9 @@
       "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -3924,7 +3926,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-zip": {
@@ -3943,9 +3945,9 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.5",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "debug": {
@@ -3979,13 +3981,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -3993,7 +3995,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -4030,7 +4032,7 @@
       "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fbjs": {
@@ -4038,13 +4040,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
       },
       "dependencies": {
         "core-js": {
@@ -4064,7 +4066,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "fg-lodash": {
@@ -4073,8 +4075,8 @@
       "integrity": "sha1-mINSU39CfaavIiEpu2OsyknmL6M=",
       "dev": true,
       "requires": {
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "lodash": "^2.4.1",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "lodash": {
@@ -4097,8 +4099,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.0"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -4107,8 +4109,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
-        "object-assign": "4.1.0"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -4123,11 +4125,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-up": {
@@ -4136,8 +4138,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -4146,7 +4148,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -4157,10 +4159,10 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "for-in": {
@@ -4175,7 +4177,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -4194,9 +4196,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "freeport": {
@@ -4210,9 +4212,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
       }
     },
     "fs.realpath": {
@@ -4227,8 +4229,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -5129,10 +5131,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       },
       "dependencies": {
         "inherits": {
@@ -5160,9 +5162,9 @@
       "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
       "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
+        "fstream": "^1.0.0",
+        "inherits": "2",
+        "minimatch": "^3.0.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -5175,7 +5177,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5194,7 +5196,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -5210,14 +5212,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5235,7 +5237,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -5246,7 +5248,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "^1.0.0"
       }
     },
     "generate-function": {
@@ -5261,7 +5263,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-func-name": {
@@ -5275,7 +5277,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gherkin": {
@@ -5303,8 +5305,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -5313,7 +5315,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globals": {
@@ -5328,12 +5330,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.1",
-        "object-assign": "4.1.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "globule": {
@@ -5342,9 +5344,9 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.4",
+        "minimatch": "~3.0.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -5359,7 +5361,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5369,12 +5371,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -5383,7 +5385,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -5405,29 +5407,29 @@
       "integrity": "sha1-h+N6Bum0meiXkOLcERqpZotuYX8=",
       "dev": true,
       "requires": {
-        "accept": "1.0.0",
-        "ammo": "1.0.0",
-        "boom": "2.7.2",
-        "call": "2.0.1",
-        "catbox": "4.3.0",
-        "catbox-memory": "1.1.1",
-        "cryptiles": "2.0.4",
-        "h2o2": "4.0.1",
-        "heavy": "3.0.0",
-        "hoek": "2.14.0",
-        "inert": "2.1.5",
-        "iron": "2.1.2",
-        "items": "1.1.0",
-        "joi": "6.4.1",
-        "kilt": "1.1.1",
-        "mimos": "2.0.2",
-        "peekaboo": "1.0.0",
-        "qs": "4.0.0",
-        "shot": "1.5.3",
-        "statehood": "2.1.1",
-        "subtext": "1.1.1",
-        "topo": "1.0.2",
-        "vision": "2.0.1"
+        "accept": "1.x.x",
+        "ammo": "1.x.x",
+        "boom": "^2.5.x",
+        "call": "2.x.x",
+        "catbox": "^4.2.x",
+        "catbox-memory": "1.x.x",
+        "cryptiles": "2.x.x",
+        "h2o2": "4.x.x",
+        "heavy": "3.x.x",
+        "hoek": "^2.14.x",
+        "inert": "2.x.x",
+        "iron": "2.x.x",
+        "items": "1.x.x",
+        "joi": "6.x.x",
+        "kilt": "^1.1.x",
+        "mimos": "2.x.x",
+        "peekaboo": "1.x.x",
+        "qs": "4.x.x",
+        "shot": "1.x.x",
+        "statehood": "2.x.x",
+        "subtext": "1.x.x",
+        "topo": "1.x.x",
+        "vision": "2.x.x"
       },
       "dependencies": {
         "accept": {
@@ -5436,8 +5438,8 @@
           "integrity": "sha1-g++IOWi4WkDFARYEKCoiD/AeYq0=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "hoek": "2.14.0"
+            "boom": "2.x.x",
+            "hoek": "2.x.x"
           }
         },
         "ammo": {
@@ -5446,8 +5448,8 @@
           "integrity": "sha1-4FlIG/aAhzj66G1GT3L6DBLWeoU=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "hoek": "2.14.0"
+            "boom": "2.x.x",
+            "hoek": "2.x.x"
           }
         },
         "boom": {
@@ -5456,7 +5458,7 @@
           "integrity": "sha1-2tYo2Jf3/S4yzIIZfxMweXHPg1Q=",
           "dev": true,
           "requires": {
-            "hoek": "2.14.0"
+            "hoek": "2.x.x"
           }
         },
         "call": {
@@ -5465,8 +5467,8 @@
           "integrity": "sha1-SbQnCZQ96JoyJYqpEbWHUeI3eg4=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "hoek": "2.14.0"
+            "boom": "2.x.x",
+            "hoek": "2.x.x"
           }
         },
         "catbox": {
@@ -5475,9 +5477,9 @@
           "integrity": "sha1-IiN3vWfxKRrA4l0AAC0GWp3385o=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "hoek": "2.14.0",
-            "joi": "6.4.1"
+            "boom": "2.x.x",
+            "hoek": "2.x.x",
+            "joi": "6.x.x"
           }
         },
         "catbox-memory": {
@@ -5486,7 +5488,7 @@
           "integrity": "sha1-QqUvgLye+nJmAeltQBYDNhJIGig=",
           "dev": true,
           "requires": {
-            "hoek": "2.14.0"
+            "hoek": "2.x.x"
           }
         },
         "cryptiles": {
@@ -5495,7 +5497,7 @@
           "integrity": "sha1-CeoXdbnhx95+YKmdQqtvCM4aEoU=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2"
+            "boom": "2.x.x"
           }
         },
         "h2o2": {
@@ -5504,10 +5506,10 @@
           "integrity": "sha1-eg4rztHZcXjsVs48ykjgxW3un40=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "hoek": "2.14.0",
-            "joi": "6.4.1",
-            "wreck": "6.0.0"
+            "boom": "2.x.x",
+            "hoek": "2.x.x",
+            "joi": "6.x.x",
+            "wreck": "5.x.x"
           }
         },
         "heavy": {
@@ -5516,9 +5518,9 @@
           "integrity": "sha1-/QEIdiExYy+IVIontVQSws9SKwA=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "hoek": "2.14.0",
-            "joi": "6.4.1"
+            "boom": "2.x.x",
+            "hoek": "2.x.x",
+            "joi": "5.x.x"
           }
         },
         "hoek": {
@@ -5533,12 +5535,12 @@
           "integrity": "sha1-eybZTEHGLAPsHU726LRe1WuDSFk=",
           "dev": true,
           "requires": {
-            "ammo": "1.0.0",
-            "boom": "2.7.2",
-            "hoek": "2.14.0",
-            "items": "1.1.0",
-            "joi": "6.4.1",
-            "lru-cache": "2.6.4"
+            "ammo": "1.x.x",
+            "boom": "2.x.x",
+            "hoek": "2.x.x",
+            "items": "1.x.x",
+            "joi": "6.x.x",
+            "lru-cache": "2.6.x"
           },
           "dependencies": {
             "lru-cache": {
@@ -5555,9 +5557,9 @@
           "integrity": "sha1-WR2RiiVAdTxEbY5DfNzwz6gBEU8=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "cryptiles": "2.0.4",
-            "hoek": "2.14.0"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x"
           }
         },
         "items": {
@@ -5572,10 +5574,10 @@
           "integrity": "sha1-9Q9CRTVgBo5jg9oVrC0w3Xzra24=",
           "dev": true,
           "requires": {
-            "hoek": "2.14.0",
-            "isemail": "1.1.1",
-            "moment": "2.10.3",
-            "topo": "1.0.2"
+            "hoek": "^2.2.x",
+            "isemail": "1.x.x",
+            "moment": "2.x.x",
+            "topo": "1.x.x"
           },
           "dependencies": {
             "isemail": {
@@ -5598,7 +5600,7 @@
           "integrity": "sha1-d7SmFjyn+lshN6iMFzNCFuwj1ds=",
           "dev": true,
           "requires": {
-            "hoek": "2.14.0"
+            "hoek": "2.x.x"
           }
         },
         "mimos": {
@@ -5607,8 +5609,8 @@
           "integrity": "sha1-wyQXF+dblZkr54esfdbbGptTmx4=",
           "dev": true,
           "requires": {
-            "hoek": "2.14.0",
-            "mime-db": "1.14.0"
+            "hoek": "2.x.x",
+            "mime-db": "1.x.x"
           },
           "dependencies": {
             "mime-db": {
@@ -5637,7 +5639,7 @@
           "integrity": "sha1-SGEHREO8VHLCNRthpGtOrsAH9Xo=",
           "dev": true,
           "requires": {
-            "hoek": "2.14.0"
+            "hoek": "2.x.x"
           }
         },
         "statehood": {
@@ -5646,12 +5648,12 @@
           "integrity": "sha1-AfFwtmxeklqvZ5qdMiulkYb8AAk=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "cryptiles": "2.0.4",
-            "hoek": "2.14.0",
-            "iron": "2.1.2",
-            "items": "1.1.0",
-            "joi": "6.4.1"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "iron": "2.x.x",
+            "items": "1.x.x",
+            "joi": "6.x.x"
           }
         },
         "subtext": {
@@ -5660,12 +5662,12 @@
           "integrity": "sha1-DJGCWuZdUXhVWT2DHjPvdaKEFWs=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "content": "1.0.1",
-            "hoek": "2.14.0",
-            "pez": "1.0.0",
-            "qs": "4.0.0",
-            "wreck": "6.0.0"
+            "boom": "2.x.x",
+            "content": "1.x.x",
+            "hoek": "2.x.x",
+            "pez": "1.x.x",
+            "qs": "4.x.x",
+            "wreck": "6.x.x"
           },
           "dependencies": {
             "content": {
@@ -5674,8 +5676,8 @@
               "integrity": "sha1-gD60s7eJVGD9jGnGhMd1RmmvG6E=",
               "dev": true,
               "requires": {
-                "boom": "2.7.2",
-                "hoek": "2.14.0"
+                "boom": "2.x.x",
+                "hoek": "2.x.x"
               }
             },
             "pez": {
@@ -5684,11 +5686,11 @@
               "integrity": "sha1-hEMYpc5wku7d/6KV4YB5rHefoBg=",
               "dev": true,
               "requires": {
-                "b64": "2.0.0",
-                "boom": "2.7.2",
-                "content": "1.0.1",
-                "hoek": "2.14.0",
-                "nigel": "1.0.1"
+                "b64": "2.x.x",
+                "boom": "2.x.x",
+                "content": "1.x.x",
+                "hoek": "2.x.x",
+                "nigel": "1.x.x"
               },
               "dependencies": {
                 "b64": {
@@ -5697,7 +5699,7 @@
                   "integrity": "sha1-tZlbJPR+v9nxMQF6bntdZHVvtvM=",
                   "dev": true,
                   "requires": {
-                    "hoek": "2.14.0"
+                    "hoek": "2.x.x"
                   }
                 },
                 "nigel": {
@@ -5706,8 +5708,8 @@
                   "integrity": "sha1-RjmJr4gSePuqHTzJOCPb0XtDYKE=",
                   "dev": true,
                   "requires": {
-                    "hoek": "2.14.0",
-                    "vise": "1.0.0"
+                    "hoek": "2.x.x",
+                    "vise": "1.x.x"
                   },
                   "dependencies": {
                     "vise": {
@@ -5716,7 +5718,7 @@
                       "integrity": "sha1-KDRb5N5aNB4V/SgW/Z6j5zA+jfM=",
                       "dev": true,
                       "requires": {
-                        "hoek": "2.14.0"
+                        "hoek": "2.x.x"
                       }
                     }
                   }
@@ -5731,7 +5733,7 @@
           "integrity": "sha1-QhV8N8HeTTeIPM3R1skChHqGDbk=",
           "dev": true,
           "requires": {
-            "hoek": "2.14.0"
+            "hoek": "2.x.x"
           }
         },
         "vision": {
@@ -5740,10 +5742,10 @@
           "integrity": "sha1-0BIlW6buQm0GlqNOHfMy/sVeZzw=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "hoek": "2.14.0",
-            "items": "1.1.0",
-            "joi": "6.4.1"
+            "boom": "2.x.x",
+            "hoek": "^2.9.x",
+            "items": "^1.1.x",
+            "joi": "6.x.x"
           }
         },
         "wreck": {
@@ -5752,8 +5754,8 @@
           "integrity": "sha1-T0CGaWHl14rOBPMqa38x8/PFFjg=",
           "dev": true,
           "requires": {
-            "boom": "2.7.2",
-            "hoek": "2.14.0"
+            "boom": "2.x.x",
+            "hoek": "2.x.x"
           }
         }
       }
@@ -5768,8 +5770,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.1",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -5777,10 +5779,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
           "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         }
       }
@@ -5791,7 +5793,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -5818,8 +5820,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -5827,8 +5829,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hasha": {
@@ -5836,8 +5838,8 @@
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "hawk": {
@@ -5845,10 +5847,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       },
       "dependencies": {
         "hoek": {
@@ -5869,9 +5871,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -5885,8 +5887,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       },
       "dependencies": {
         "os-homedir": {
@@ -5902,35 +5904,30 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
       "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.2",
-        "domutils": "1.5.1",
-        "entities": "1.1.2",
-        "inherits": "2.0.3",
-        "readable-stream": "3.0.6"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6"
       },
       "dependencies": {
-        "domelementtype": {
-          "version": "1.3.0",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-          "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
-        },
         "readable-stream": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
-          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
           "requires": {
-            "inherits": "2.0.3",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -5946,9 +5943,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -5957,9 +5954,9 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "2",
+        "debug": "2",
+        "extend": "3"
       },
       "dependencies": {
         "debug": {
@@ -5989,7 +5986,7 @@
       "resolved": "https://registry.npmjs.org/iced-lock/-/iced-lock-1.1.0.tgz",
       "integrity": "sha1-YRbvHKs6zW5rEIk7snumIv0/3nI=",
       "requires": {
-        "iced-runtime": "1.0.3"
+        "iced-runtime": "^1.0.0"
       }
     },
     "iced-runtime": {
@@ -6039,19 +6036,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.0.0",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.10",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "invariant": {
@@ -6060,7 +6057,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "is-binary-path": {
@@ -6069,7 +6066,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -6102,7 +6099,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -6123,7 +6120,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       },
       "dependencies": {
         "number-is-nan": {
@@ -6139,7 +6136,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-generator": {
@@ -6154,7 +6151,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -6163,10 +6160,10 @@
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -6175,7 +6172,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-path-cwd": {
@@ -6190,7 +6187,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -6199,7 +6196,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -6232,7 +6229,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -6241,7 +6238,7 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "^1.0.1"
       }
     },
     "is-stream": {
@@ -6284,8 +6281,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -6299,8 +6296,8 @@
       "integrity": "sha512-UQc+xLLn+0a8KKRXRj3OS2kERK8G7zcayPpPULqZnPwuJ1hGWEO8+j0T5eycu7DKXYjezw3pyF8oV1fJkJxV5w==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "lodash.get": "4.4.2"
+        "babel-runtime": "6.x.x",
+        "lodash.get": "^4.4.2"
       }
     },
     "jasmine": {
@@ -6309,9 +6306,9 @@
       "integrity": "sha1-jKctEC5jm4Z8ZImFbg4YqceqQrc=",
       "dev": true,
       "requires": {
-        "exit": "0.1.2",
-        "glob": "7.1.2",
-        "jasmine-core": "2.99.1"
+        "exit": "^0.1.2",
+        "glob": "^7.0.6",
+        "jasmine-core": "~2.99.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -6326,7 +6323,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -6336,12 +6333,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -6350,7 +6347,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -6378,8 +6375,8 @@
       "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -6404,10 +6401,10 @@
       "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.3.7.tgz",
       "integrity": "sha1-jzrApodbmNLBO1lQZJ2QP+y5jkE=",
       "requires": {
-        "chance": "1.0.12",
-        "deref": "0.6.4",
-        "faker": "3.1.0",
-        "randexp": "0.4.6"
+        "chance": "^1.0.4",
+        "deref": "^0.6.4",
+        "faker": "~3.1.0",
+        "randexp": "~0.4.3"
       }
     },
     "json-schema-traverse": {
@@ -6420,7 +6417,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -6439,7 +6436,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -6458,11 +6455,11 @@
       "resolved": "https://registry.npmjs.org/jsontokens/-/jsontokens-0.7.7.tgz",
       "integrity": "sha512-IuW4Q7gj9Hm/ZSjT7U5PEI1ZS8sfPj2ZOV9+5kEo4iVYVSjfs25wPvNUpq/Mkmdmz3VIe1KWIBwIBv2M+ML1Fw==",
       "requires": {
-        "asn1.js": "4.10.1",
-        "base64url": "2.0.0",
-        "elliptic": "6.4.0",
-        "key-encoder": "1.1.6",
-        "validator": "7.2.0"
+        "asn1.js": "^4.9.1",
+        "base64url": "^2.0.0",
+        "elliptic": "^6.3.2",
+        "key-encoder": "^1.1.6",
+        "validator": "^7.0.0"
       }
     },
     "jsprim": {
@@ -6492,9 +6489,9 @@
       "resolved": "https://registry.npmjs.org/key-encoder/-/key-encoder-1.1.6.tgz",
       "integrity": "sha1-ATVYLNPQp+t5LZTso4e2gejloq0=",
       "requires": {
-        "asn1.js": "2.2.1",
-        "bn.js": "3.3.0",
-        "elliptic": "5.2.1"
+        "asn1.js": "^2.2.0",
+        "bn.js": "^3.1.2",
+        "elliptic": "^5.1.0"
       },
       "dependencies": {
         "asn1.js": {
@@ -6502,9 +6499,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
           "integrity": "sha1-yLpN1o6EQxKIEmIwyyBFvfqfv+E=",
           "requires": {
-            "bn.js": "2.2.0",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^2.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           },
           "dependencies": {
             "bn.js": {
@@ -6524,10 +6521,10 @@
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz",
           "integrity": "sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=",
           "requires": {
-            "bn.js": "3.3.0",
-            "brorand": "1.1.0",
-            "hash.js": "1.1.3",
-            "inherits": "2.0.3"
+            "bn.js": "^3.1.1",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
           }
         }
       }
@@ -6538,7 +6535,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -6546,7 +6543,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazystream": {
@@ -6555,7 +6552,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5"
+        "readable-stream": "^2.0.5"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -6570,13 +6567,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -6585,7 +6582,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -6596,8 +6593,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -6712,7 +6709,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       },
       "dependencies": {
         "js-tokens": {
@@ -6733,9 +6730,9 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -6756,28 +6753,28 @@
       "integrity": "sha512-TI1aQRK0vqs94OCkUMkmf5lXNWfIsjSaEDP1inUuwRGt9w8/S2V+HdRikz9r1k/gew+7NcJieaqHsHX7pSTEgA==",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
+        "assert": "^1.4.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.9.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.7",
+        "events": "^1.1.1",
         "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
+        "os-browserify": "^0.2.1",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
+        "process": "^0.11.9",
+        "punycode": "^1.4.1",
+        "querystring-es3": "^0.2.1",
         "readable-stream": "git+https://github.com/meteor/readable-stream.git#c688cdd193549919b840e8d72a86682d91961e12",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
-        "string_decoder": "1.1.0",
-        "timers-browserify": "1.4.2",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.8.0",
+        "string_decoder": "^1.1.0",
+        "timers-browserify": "^1.4.2",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -6787,9 +6784,9 @@
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.1",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "assert": {
@@ -6823,7 +6820,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -6839,12 +6836,12 @@
           "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
           "dev": true,
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.1",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "browserify-cipher": {
@@ -6853,9 +6850,9 @@
           "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
           "dev": true,
           "requires": {
-            "browserify-aes": "1.1.1",
-            "browserify-des": "1.0.0",
-            "evp_bytestokey": "1.0.3"
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
           }
         },
         "browserify-des": {
@@ -6864,9 +6861,9 @@
           "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
           "dev": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "des.js": "1.0.0",
-            "inherits": "2.0.1"
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "browserify-rsa": {
@@ -6875,8 +6872,8 @@
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "randombytes": "2.0.6"
+            "bn.js": "^4.1.0",
+            "randombytes": "^2.0.1"
           }
         },
         "browserify-sign": {
@@ -6885,13 +6882,13 @@
           "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "browserify-rsa": "4.0.1",
-            "create-hash": "1.1.3",
-            "create-hmac": "1.1.6",
-            "elliptic": "6.4.0",
-            "inherits": "2.0.1",
-            "parse-asn1": "5.1.0"
+            "bn.js": "^4.1.1",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.2",
+            "elliptic": "^6.0.0",
+            "inherits": "^2.0.1",
+            "parse-asn1": "^5.0.0"
           }
         },
         "browserify-zlib": {
@@ -6900,7 +6897,7 @@
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "dev": true,
           "requires": {
-            "pako": "0.2.9"
+            "pako": "~0.2.0"
           }
         },
         "buffer": {
@@ -6909,9 +6906,9 @@
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "dev": true,
           "requires": {
-            "base64-js": "1.2.3",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         },
         "buffer-xor": {
@@ -6932,8 +6929,8 @@
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.1",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "concat-map": {
@@ -6947,7 +6944,7 @@
           "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "dev": true,
           "requires": {
-            "date-now": "0.1.4"
+            "date-now": "^0.1.4"
           }
         },
         "constants-browserify": {
@@ -6962,8 +6959,8 @@
           "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "elliptic": "6.4.0"
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.0.0"
           }
         },
         "create-hash": {
@@ -6972,10 +6969,10 @@
           "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
           "dev": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "inherits": "2.0.1",
-            "ripemd160": "2.0.1",
-            "sha.js": "2.4.10"
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "sha.js": "^2.4.0"
           }
         },
         "create-hmac": {
@@ -6984,12 +6981,12 @@
           "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
           "dev": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "inherits": "2.0.1",
-            "ripemd160": "2.0.1",
-            "safe-buffer": "5.1.1",
-            "sha.js": "2.4.10"
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
           }
         },
         "crypto-browserify": {
@@ -6998,17 +6995,17 @@
           "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
           "dev": true,
           "requires": {
-            "browserify-cipher": "1.0.0",
-            "browserify-sign": "4.0.4",
-            "create-ecdh": "4.0.0",
-            "create-hash": "1.1.3",
-            "create-hmac": "1.1.6",
-            "diffie-hellman": "5.0.2",
-            "inherits": "2.0.1",
-            "pbkdf2": "3.0.14",
-            "public-encrypt": "4.0.0",
-            "randombytes": "2.0.6",
-            "randomfill": "1.0.4"
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
           }
         },
         "date-now": {
@@ -7023,8 +7020,8 @@
           "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.1",
-            "minimalistic-assert": "1.0.0"
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "diffie-hellman": {
@@ -7033,9 +7030,9 @@
           "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "miller-rabin": "4.0.1",
-            "randombytes": "2.0.6"
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
           }
         },
         "domain-browser": {
@@ -7050,13 +7047,13 @@
           "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "brorand": "1.1.0",
-            "hash.js": "1.1.3",
-            "hmac-drbg": "1.0.1",
-            "inherits": "2.0.1",
-            "minimalistic-assert": "1.0.0",
-            "minimalistic-crypto-utils": "1.0.1"
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
           }
         },
         "events": {
@@ -7071,8 +7068,8 @@
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "dev": true,
           "requires": {
-            "md5.js": "1.3.4",
-            "safe-buffer": "5.1.1"
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
           }
         },
         "fs.realpath": {
@@ -7085,12 +7082,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "hash-base": {
@@ -7099,7 +7096,7 @@
           "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.1"
+            "inherits": "^2.0.1"
           }
         },
         "hash.js": {
@@ -7108,8 +7105,8 @@
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
           },
           "dependencies": {
             "inherits": {
@@ -7126,9 +7123,9 @@
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "dev": true,
           "requires": {
-            "hash.js": "1.1.3",
-            "minimalistic-assert": "1.0.0",
-            "minimalistic-crypto-utils": "1.0.1"
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
           }
         },
         "https-browserify": {
@@ -7154,8 +7151,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -7175,8 +7172,8 @@
           "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
           "dev": true,
           "requires": {
-            "hash-base": "3.0.4",
-            "inherits": "2.0.1"
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
           },
           "dependencies": {
             "hash-base": {
@@ -7185,8 +7182,8 @@
               "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.1",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
               }
             }
           }
@@ -7197,8 +7194,8 @@
           "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "brorand": "1.1.0"
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
           }
         },
         "minimalistic-assert": {
@@ -7218,7 +7215,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "once": {
@@ -7226,7 +7223,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-browserify": {
@@ -7247,11 +7244,11 @@
           "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
           "dev": true,
           "requires": {
-            "asn1.js": "4.10.1",
-            "browserify-aes": "1.1.1",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "pbkdf2": "3.0.14"
+            "asn1.js": "^4.0.0",
+            "browserify-aes": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3"
           }
         },
         "path-browserify": {
@@ -7271,11 +7268,11 @@
           "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
           "dev": true,
           "requires": {
-            "create-hash": "1.1.3",
-            "create-hmac": "1.1.6",
-            "ripemd160": "2.0.1",
-            "safe-buffer": "5.1.1",
-            "sha.js": "2.4.10"
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
           }
         },
         "process": {
@@ -7296,11 +7293,11 @@
           "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "browserify-rsa": "4.0.1",
-            "create-hash": "1.1.3",
-            "parse-asn1": "5.1.0",
-            "randombytes": "2.0.6"
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1"
           }
         },
         "punycode": {
@@ -7327,7 +7324,7 @@
           "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.1.0"
           }
         },
         "randomfill": {
@@ -7336,20 +7333,21 @@
           "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
           "dev": true,
           "requires": {
-            "randombytes": "2.0.6",
-            "safe-buffer": "5.1.1"
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
           }
         },
         "readable-stream": {
           "version": "git+https://github.com/meteor/readable-stream.git#c688cdd193549919b840e8d72a86682d91961e12",
+          "from": "readable-stream@git+https://github.com/meteor/readable-stream.git#c688cdd193549919b840e8d72a86682d91961e12",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.0",
-            "util-deprecate": "1.0.2"
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.0",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "inherits": {
@@ -7365,7 +7363,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "ripemd160": {
@@ -7374,8 +7372,8 @@
           "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
           "dev": true,
           "requires": {
-            "hash-base": "2.0.2",
-            "inherits": "2.0.1"
+            "hash-base": "^2.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "safe-buffer": {
@@ -7390,8 +7388,8 @@
           "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.1",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "stream-browserify": {
@@ -7400,8 +7398,8 @@
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.1",
-            "readable-stream": "git+https://github.com/meteor/readable-stream.git#c688cdd193549919b840e8d72a86682d91961e12"
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "stream-http": {
@@ -7410,11 +7408,11 @@
           "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
           "dev": true,
           "requires": {
-            "builtin-status-codes": "3.0.0",
-            "inherits": "2.0.1",
-            "readable-stream": "git+https://github.com/meteor/readable-stream.git#c688cdd193549919b840e8d72a86682d91961e12",
-            "to-arraybuffer": "1.0.1",
-            "xtend": "4.0.1"
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.3",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "string_decoder": {
@@ -7423,7 +7421,7 @@
           "integrity": "sha512-8zQpRF6juocE69ae7CSPmYEGJe4VCXwP6S6dxUWI7i53Gwv54/ec41fiUA+X7BPGGv7fRSQJjBQVa0gomGaOgg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "timers-browserify": {
@@ -7432,7 +7430,7 @@
           "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
           "dev": true,
           "requires": {
-            "process": "0.11.10"
+            "process": "~0.11.0"
           }
         },
         "to-arraybuffer": {
@@ -7514,19 +7512,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime-db": {
@@ -7539,7 +7537,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimic-fn": {
@@ -7610,7 +7608,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -7635,12 +7633,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -7655,7 +7653,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "ms": {
@@ -7670,7 +7668,7 @@
           "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -7680,7 +7678,7 @@
       "resolved": "https://registry.npmjs.org/more-entropy/-/more-entropy-0.0.7.tgz",
       "integrity": "sha1-Z7/G96hvJvvDeqyD/UbYjGHRCbU=",
       "requires": {
-        "iced-runtime": "1.0.3"
+        "iced-runtime": ">=0.0.1"
       }
     },
     "ms": {
@@ -7718,7 +7716,7 @@
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-fetch": {
@@ -7726,8 +7724,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-pre-gyp": {
@@ -7735,15 +7733,15 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
       "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
       "requires": {
-        "mkdirp": "0.5.1",
-        "nopt": "4.0.1",
-        "npmlog": "4.1.2",
-        "rc": "1.2.2",
-        "request": "2.83.0",
-        "rimraf": "2.6.1",
-        "semver": "5.4.1",
-        "tar": "2.2.1",
-        "tar-pack": "3.4.1"
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "npmlog": "^4.0.2",
+        "rc": "^1.1.7",
+        "request": "^2.81.0",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^2.2.1",
+        "tar-pack": "^3.4.0"
       },
       "dependencies": {
         "minimist": {
@@ -7772,8 +7770,8 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.4"
+        "abbrev": "1",
+        "osenv": "^0.1.4"
       }
     },
     "normalize-path": {
@@ -7782,7 +7780,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -7801,10 +7799,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -7812,7 +7810,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -7847,9 +7845,9 @@
       "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "object-keys": "1.0.11"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.0",
+        "object-keys": "^1.0.10"
       }
     },
     "object.omit": {
@@ -7858,8 +7856,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "once": {
@@ -7888,8 +7886,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -7906,12 +7904,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -7930,8 +7928,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       },
       "dependencies": {
         "os-homedir": {
@@ -7953,10 +7951,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "path-exists": {
@@ -7999,11 +7997,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "pend": {
@@ -8021,15 +8019,15 @@
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "requires": {
-        "es6-promise": "4.2.4",
-        "extract-zip": "1.6.6",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.83.0",
-        "request-progress": "2.0.1",
-        "which": "1.2.14"
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
       }
     },
     "pify": {
@@ -8048,7 +8046,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -8057,7 +8055,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pkg-up": {
@@ -8066,7 +8064,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pluralize": {
@@ -8080,10 +8078,10 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
       "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "requires": {
-        "chalk": "1.1.3",
-        "js-base64": "2.4.0",
-        "source-map": "0.5.7",
-        "supports-color": "3.2.3"
+        "chalk": "^1.1.3",
+        "js-base64": "^2.1.9",
+        "source-map": "^0.5.6",
+        "supports-color": "^3.2.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8101,11 +8099,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -8125,7 +8123,7 @@
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -8133,7 +8131,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -8141,7 +8139,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8185,7 +8183,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -8193,9 +8191,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -8206,9 +8204,9 @@
       }
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "punycode": {
       "version": "1.4.1",
@@ -8220,7 +8218,7 @@
       "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
       "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
       "requires": {
-        "bitcoin-ops": "1.4.1"
+        "bitcoin-ops": "^1.3.0"
       }
     },
     "q": {
@@ -8239,8 +8237,8 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
-        "object-assign": "4.1.0",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -8255,7 +8253,7 @@
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "requires": {
         "discontinuous-range": "1.0.0",
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "randomatic": {
@@ -8264,8 +8262,8 @@
       "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -8274,7 +8272,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -8283,7 +8281,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -8294,7 +8292,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8304,7 +8302,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -8312,8 +8310,8 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "rc": {
@@ -8321,10 +8319,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -8339,11 +8337,11 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
-        "create-react-class": "15.6.2",
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "create-react-class": "^15.6.0",
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
       },
       "dependencies": {
         "object-assign": {
@@ -8358,8 +8356,8 @@
       "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-15.6.2.tgz",
       "integrity": "sha1-a4P0C2s27kBzXL1hJes/E84c3ck=",
       "requires": {
-        "fbjs": "0.8.16",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.4",
+        "object-assign": "^4.1.0"
       },
       "dependencies": {
         "object-assign": {
@@ -8374,10 +8372,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
       },
       "dependencies": {
         "object-assign": {
@@ -8412,10 +8410,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.5",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       },
       "dependencies": {
         "balanced-match": {
@@ -8430,7 +8428,7 @@
           "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -8440,7 +8438,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "process-nextick-args": {
@@ -8455,13 +8453,13 @@
           "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -8470,7 +8468,7 @@
           "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -8481,8 +8479,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -8504,9 +8502,9 @@
       "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -8515,7 +8513,7 @@
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexpu-core": {
@@ -8524,9 +8522,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -8541,7 +8539,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -8576,7 +8574,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -8584,28 +8582,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-progress": {
@@ -8613,7 +8611,7 @@
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "requires": {
-        "throttleit": "1.0.0"
+        "throttleit": "^1.0.0"
       }
     },
     "requestretry": {
@@ -8623,7 +8621,7 @@
       "dev": true,
       "requires": {
         "fg-lodash": "0.0.2",
-        "request": "2.83.0"
+        "request": "^2.62.x"
       }
     },
     "require-uncached": {
@@ -8632,8 +8630,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -8660,8 +8658,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "ret": {
@@ -8680,7 +8678,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "requires": {
-        "glob": "7.1.1"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -8688,8 +8686,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "run-async": {
@@ -8698,7 +8696,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "rx-lite": {
@@ -8713,7 +8711,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "3.1.2"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -8727,7 +8725,7 @@
       "integrity": "sha1-uTSpr52ih0s/QKrh/N5QpEZvXzg=",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "1.0.0"
+        "https-proxy-agent": "^1.0.0"
       }
     },
     "schema-inspector": {
@@ -8735,7 +8733,7 @@
       "resolved": "https://registry.npmjs.org/schema-inspector/-/schema-inspector-1.6.8.tgz",
       "integrity": "sha1-ueU5g8xV/y29e2Xj2+CF2dEoXyo=",
       "requires": {
-        "async": "1.5.2"
+        "async": "^1.5.0"
       }
     },
     "selenium-standalone": {
@@ -8744,19 +8742,19 @@
       "integrity": "sha1-1h0plOGWsv9hoZ3kmMZxE3X1pRs=",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "commander": "2.15.1",
-        "cross-spawn": "6.0.5",
-        "debug": "3.1.0",
-        "lodash": "4.17.10",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
+        "async": "^2.1.4",
+        "commander": "^2.9.0",
+        "cross-spawn": "^6.0.0",
+        "debug": "^3.0.0",
+        "lodash": "^4.17.4",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
         "progress": "2.0.0",
         "request": "2.79.0",
         "tar-stream": "1.5.2",
-        "urijs": "1.19.1",
-        "which": "1.2.14",
-        "yauzl": "2.9.1"
+        "urijs": "^1.18.4",
+        "which": "^1.2.12",
+        "yauzl": "^2.5.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -8771,7 +8769,7 @@
           "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.14.0"
           }
         },
         "aws-sign2": {
@@ -8786,7 +8784,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "caseless": {
@@ -8801,7 +8799,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "debug": {
@@ -8819,9 +8817,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "har-validator": {
@@ -8830,10 +8828,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.15.1",
-            "is-my-json-valid": "2.16.1",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "hawk": {
@@ -8842,10 +8840,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -8860,9 +8858,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "minimist": {
@@ -8895,26 +8893,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
           }
         },
         "sntp": {
@@ -8923,7 +8921,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "tunnel-agent": {
@@ -8938,8 +8936,8 @@
           "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
           "dev": true,
           "requires": {
-            "buffer-crc32": "0.2.13",
-            "fd-slicer": "1.0.1"
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.0.1"
           }
         }
       }
@@ -8967,11 +8965,11 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -8980,7 +8978,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -8995,8 +8993,8 @@
       "integrity": "sha1-+wv239Zu/86KEWnPn+KnOwK9w50=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "xtend": "4.0.1"
+        "concat-stream": "^1.4.7",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "concat-stream": {
@@ -9005,9 +9003,9 @@
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "core-util-is": {
@@ -9040,13 +9038,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -9055,7 +9053,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "typedarray": {
@@ -9084,9 +9082,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -9101,7 +9099,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -9123,12 +9121,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "inflight": {
@@ -9137,8 +9135,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -9159,7 +9157,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "once": {
@@ -9168,7 +9166,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "path-is-absolute": {
@@ -9183,7 +9181,7 @@
           "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
           "dev": true,
           "requires": {
-            "resolve": "1.5.0"
+            "resolve": "^1.1.6"
           }
         },
         "resolve": {
@@ -9192,7 +9190,7 @@
           "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         },
         "wrappy": {
@@ -9225,7 +9223,7 @@
       "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.1.tgz",
       "integrity": "sha1-rwj2CKfBFRa2F3iqgA3OhMUYz9o=",
       "requires": {
-        "unicode": "10.0.0"
+        "unicode": ">= 0.3.1"
       }
     },
     "sntp": {
@@ -9233,7 +9231,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       },
       "dependencies": {
         "hoek": {
@@ -9254,10 +9252,10 @@
       "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
       "dev": true,
       "requires": {
-        "atob": "1.1.3",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.3.0",
-        "urix": "0.1.0"
+        "atob": "~1.1.0",
+        "resolve-url": "~0.2.1",
+        "source-map-url": "~0.3.0",
+        "urix": "~0.1.0"
       }
     },
     "source-map-support": {
@@ -9266,7 +9264,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -9285,14 +9283,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-chain": {
@@ -9307,7 +9305,7 @@
       "integrity": "sha1-NvapIHUabBD0maE8Msu19RoLiyU=",
       "dev": true,
       "requires": {
-        "stackframe": "1.0.4"
+        "stackframe": "^1.0.2"
       },
       "dependencies": {
         "stackframe": {
@@ -9331,7 +9329,7 @@
       "dev": true,
       "requires": {
         "source-map": "0.5.6",
-        "stackframe": "0.3.1"
+        "stackframe": "~0.3"
       },
       "dependencies": {
         "source-map": {
@@ -9348,9 +9346,9 @@
       "integrity": "sha1-Z8qyWJr1xBe5Yvc2mUAne7O2oYs=",
       "dev": true,
       "requires": {
-        "error-stack-parser": "1.3.6",
-        "stack-generator": "1.1.0",
-        "stacktrace-gps": "2.4.4"
+        "error-stack-parser": "^1.3.6",
+        "stack-generator": "^1.0.7",
+        "stacktrace-gps": "^2.4.3"
       }
     },
     "strict-uri-encode": {
@@ -9363,9 +9361,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -9410,12 +9408,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.10",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9436,8 +9434,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -9446,7 +9444,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -9456,9 +9454,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       },
       "dependencies": {
         "inherits": {
@@ -9473,14 +9471,14 @@
       "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.1.tgz",
       "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
       "requires": {
-        "debug": "2.6.9",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.4.0",
-        "readable-stream": "2.3.3",
-        "rimraf": "2.6.1",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
+        "debug": "^2.2.0",
+        "fstream": "^1.0.10",
+        "fstream-ignore": "^1.0.5",
+        "once": "^1.3.3",
+        "readable-stream": "^2.1.4",
+        "rimraf": "^2.5.1",
+        "tar": "^2.2.1",
+        "uid-number": "^0.0.6"
       },
       "dependencies": {
         "core-util-is": {
@@ -9516,7 +9514,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "process-nextick-args": {
@@ -9529,13 +9527,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -9543,7 +9541,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "util-deprecate": {
@@ -9564,10 +9562,10 @@
       "integrity": "sha1-+8bG6DwaGdTLSMfZYXH8JI7/x78=",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.5",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -9582,13 +9580,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -9597,7 +9595,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -9624,11 +9622,11 @@
       "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.0.1.tgz",
       "integrity": "sha512-Wz2kMPWtCI5XBftFeF3bUL8uz2+VlasniKwOkRPjvL7h1QVd9rbhrve/HWUu747kJKzVf1XHonzcdM4Ut8fvww==",
       "requires": {
-        "bindings": "1.3.0",
-        "bn.js": "4.11.8",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
-        "nan": "2.10.0"
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.10.0"
       }
     },
     "tmp": {
@@ -9637,7 +9635,7 @@
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-fast-properties": {
@@ -9651,7 +9649,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-right": {
@@ -9665,12 +9663,12 @@
       "resolved": "https://registry.npmjs.org/triplesec/-/triplesec-3.0.27.tgz",
       "integrity": "sha512-FDhkxa3JYnPOerOd+8k+SBmm7cb7KkyX+xXwNFV3XV6dsQgHuRvjtbnzWfPJ2kimeR8ErjZfPd/6r7RH6epHDw==",
       "requires": {
-        "iced-error": "0.0.13",
-        "iced-lock": "1.1.0",
-        "iced-runtime": "1.0.3",
-        "more-entropy": "0.0.7",
-        "progress": "1.1.8",
-        "uglify-js": "3.4.9"
+        "iced-error": ">=0.0.9",
+        "iced-lock": "^1.0.1",
+        "iced-runtime": "^1.0.2",
+        "more-entropy": ">=0.0.7",
+        "progress": "~1.1.2",
+        "uglify-js": "^3.1.9"
       }
     },
     "tryit": {
@@ -9684,7 +9682,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -9699,7 +9697,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -9714,9 +9712,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typeforce": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.16.0.tgz",
-      "integrity": "sha512-V60F7OHPH7vPlgIU73vYyeebKxWjQqCTlge+MvKlVn09PIhCOi/ZotowYdgREHB5S1dyHOr906ui6NheYXjlVQ=="
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "ua-parser-js": {
       "version": "0.7.17",
@@ -9728,8 +9726,8 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "requires": {
-        "commander": "2.17.1",
-        "source-map": "0.6.1"
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -9782,7 +9780,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -9842,7 +9840,7 @@
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
       "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "verror": {
@@ -9850,9 +9848,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "core-util-is": {
@@ -9875,8 +9873,8 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.23.0",
-        "fibers": "1.0.15",
-        "object.assign": "4.0.4"
+        "fibers": "~1.0.15",
+        "object.assign": "^4.0.3"
       },
       "dependencies": {
         "babel-runtime": {
@@ -9885,8 +9883,8 @@
           "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.5",
-            "regenerator-runtime": "0.10.5"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.10.0"
           }
         }
       }
@@ -9897,27 +9895,27 @@
       "integrity": "sha1-40De8nIYPIFopN0LOCMi+de+4Q0=",
       "dev": true,
       "requires": {
-        "archiver": "2.1.1",
-        "babel-runtime": "6.26.0",
-        "css-parse": "2.0.0",
-        "css-value": "0.0.1",
-        "deepmerge": "2.0.1",
-        "ejs": "2.5.8",
-        "gaze": "1.1.2",
-        "glob": "7.1.2",
-        "inquirer": "3.3.0",
-        "json-stringify-safe": "5.0.1",
-        "mkdirp": "0.5.1",
-        "npm-install-package": "2.1.0",
-        "optimist": "0.6.1",
-        "q": "1.5.1",
-        "request": "2.83.0",
-        "rgb2hex": "0.1.0",
-        "safe-buffer": "5.1.1",
-        "supports-color": "5.0.1",
-        "url": "0.11.0",
-        "wdio-dot-reporter": "0.0.9",
-        "wgxpath": "1.0.0"
+        "archiver": "~2.1.0",
+        "babel-runtime": "^6.26.0",
+        "css-parse": "~2.0.0",
+        "css-value": "~0.0.1",
+        "deepmerge": "~2.0.1",
+        "ejs": "~2.5.6",
+        "gaze": "~1.1.2",
+        "glob": "~7.1.1",
+        "inquirer": "~3.3.0",
+        "json-stringify-safe": "~5.0.1",
+        "mkdirp": "~0.5.1",
+        "npm-install-package": "~2.1.0",
+        "optimist": "~0.6.1",
+        "q": "~1.5.0",
+        "request": "~2.83.0",
+        "rgb2hex": "~0.1.0",
+        "safe-buffer": "~5.1.1",
+        "supports-color": "~5.0.0",
+        "url": "~0.11.0",
+        "wdio-dot-reporter": "~0.0.8",
+        "wgxpath": "~1.0.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -9938,7 +9936,7 @@
           "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "balanced-match": {
@@ -9953,7 +9951,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -9963,9 +9961,9 @@
           "integrity": "sha1-JQ3JawdJG/1gHmSNZt319gx6XGU=",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           },
           "dependencies": {
             "supports-color": {
@@ -9974,7 +9972,7 @@
               "integrity": "sha1-WySsFduA+pJ89SJ6SjP9PEx2dsA=",
               "dev": true,
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -9985,7 +9983,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "figures": {
@@ -9994,7 +9992,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "glob": {
@@ -10003,12 +10001,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-flag": {
@@ -10023,20 +10021,20 @@
           "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.3.2",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.1.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.10",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "is-fullwidth-code-point": {
@@ -10051,7 +10049,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "mute-stream": {
@@ -10066,7 +10064,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -10075,8 +10073,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "run-async": {
@@ -10085,7 +10083,7 @@
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
           "dev": true,
           "requires": {
-            "is-promise": "2.1.0"
+            "is-promise": "^2.1.0"
           }
         },
         "rx-lite": {
@@ -10100,8 +10098,8 @@
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -10110,7 +10108,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -10119,7 +10117,7 @@
           "integrity": "sha1-HFMx8iJQyEICgFsvF63xZpnzo5o=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           },
           "dependencies": {
             "has-flag": {
@@ -10138,8 +10136,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.11",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -10164,7 +10162,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wide-align": {
@@ -10172,7 +10170,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "wif": {
@@ -10180,7 +10178,7 @@
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
       "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
       "requires": {
-        "bs58check": "2.1.2"
+        "bs58check": "<3.0.0"
       }
     },
     "words-to-numbers": {
@@ -10189,9 +10187,9 @@
       "integrity": "sha512-r4KhP+e142csQuzLsi/h9ALP2jMMto4rPilr3eiM0qRF0rZcvDGCG4YrC25aJG99Jp07s+MdvZMo/rUcsBhwjw==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "clj-fuzzy": "0.3.3",
-        "its-set": "1.2.3"
+        "babel-runtime": "6.x.x",
+        "clj-fuzzy": "^0.3.2",
+        "its-set": "^1.1.5"
       }
     },
     "wordwrap": {
@@ -10211,7 +10209,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "xolvio-ddp": {
@@ -10220,11 +10218,11 @@
       "integrity": "sha1-NqarlhKyQLWg0cCoNJCK8XwLjwI=",
       "dev": true,
       "requires": {
-        "bluebird": "2.11.0",
+        "bluebird": "^2.9.24",
         "ddp-ejson": "0.8.1-3",
         "ddp-underscore-patched": "0.8.1-2",
-        "faye-websocket": "0.9.4",
-        "request": "2.53.0"
+        "faye-websocket": "~0.9.4",
+        "request": "2.53.x"
       },
       "dependencies": {
         "asn1": {
@@ -10257,7 +10255,7 @@
           "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34"
+            "readable-stream": "~1.0.26"
           }
         },
         "bluebird": {
@@ -10272,7 +10270,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "caseless": {
@@ -10296,7 +10294,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "delayed-stream": {
@@ -10317,9 +10315,9 @@
           "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
           "dev": true,
           "requires": {
-            "async": "0.9.2",
-            "combined-stream": "0.0.7",
-            "mime-types": "2.0.14"
+            "async": "~0.9.0",
+            "combined-stream": "~0.0.4",
+            "mime-types": "~2.0.3"
           }
         },
         "hawk": {
@@ -10328,10 +10326,10 @@
           "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -10347,7 +10345,7 @@
           "dev": true,
           "requires": {
             "asn1": "0.1.11",
-            "assert-plus": "0.1.5",
+            "assert-plus": "^0.1.5",
             "ctype": "0.5.3"
           }
         },
@@ -10369,7 +10367,7 @@
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "dev": true,
           "requires": {
-            "mime-db": "1.12.0"
+            "mime-db": "~1.12.0"
           }
         },
         "oauth-sign": {
@@ -10390,10 +10388,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "request": {
@@ -10402,23 +10400,23 @@
           "integrity": "sha1-GAo66St7Y5gC5PlUXdj83rcddgw=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.5.0",
-            "bl": "0.9.5",
-            "caseless": "0.9.0",
-            "combined-stream": "0.0.7",
-            "forever-agent": "0.5.2",
-            "form-data": "0.2.0",
-            "hawk": "2.3.1",
-            "http-signature": "0.10.1",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.0.14",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.6.0",
-            "qs": "2.3.3",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3"
+            "aws-sign2": "~0.5.0",
+            "bl": "~0.9.0",
+            "caseless": "~0.9.0",
+            "combined-stream": "~0.0.5",
+            "forever-agent": "~0.5.0",
+            "form-data": "~0.2.0",
+            "hawk": "~2.3.0",
+            "http-signature": "~0.10.0",
+            "isstream": "~0.1.1",
+            "json-stringify-safe": "~5.0.0",
+            "mime-types": "~2.0.1",
+            "node-uuid": "~1.4.0",
+            "oauth-sign": "~0.6.0",
+            "qs": "~2.3.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": ">=0.12.0",
+            "tunnel-agent": "~0.4.0"
           }
         },
         "sntp": {
@@ -10427,7 +10425,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "string_decoder": {
@@ -10450,8 +10448,8 @@
       "integrity": "sha1-vsjXDHQGGjFjFbun0w0lyz6C3FA=",
       "dev": true,
       "requires": {
-        "fibers": "1.0.15",
-        "underscore": "1.8.3"
+        "fibers": "^1.0.7",
+        "underscore": "^1.8.3"
       }
     },
     "xolvio-jasmine-expect": {
@@ -10460,7 +10458,7 @@
       "integrity": "sha1-vCud1ghCMR8EV59agtzqaisxnH0=",
       "dev": true,
       "requires": {
-        "jasmine-core": "2.99.1"
+        "jasmine-core": "^2.4.1"
       }
     },
     "xolvio-sync-webdriverio": {
@@ -10469,12 +10467,12 @@
       "integrity": "sha1-WRri2MiqynQiZJWfzM+QtPndUWA=",
       "dev": true,
       "requires": {
-        "fibers": "1.0.15",
-        "meteor-promise": "0.8.6",
-        "underscore": "1.8.3",
-        "wdio-sync": "0.6.14",
-        "webdriverio": "4.12.0",
-        "xolvio-fiber-utils": "2.0.3"
+        "fibers": "^1.0.7",
+        "meteor-promise": "^0.8.2",
+        "underscore": "^1.8.3",
+        "wdio-sync": "^0.6.6",
+        "webdriverio": "^4.4.0",
+        "xolvio-fiber-utils": "^2.0.3"
       }
     },
     "xtend": {
@@ -10489,8 +10487,8 @@
       "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "glob": "7.1.2"
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "balanced-match": {
@@ -10505,7 +10503,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -10515,12 +10513,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -10529,7 +10527,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -10539,7 +10537,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "zip-stream": {
@@ -10548,10 +10546,10 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "compress-commons": "1.2.2",
-        "lodash": "4.17.10",
-        "readable-stream": "2.3.5"
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -10566,13 +10564,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -10581,7 +10579,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bcrypt": "^1.0.3",
     "bcryptjs": "^2.4.0",
     "bindings": "^1.2.1",
-    "blockstack": "^18.1.0",
+    "blockstack": "^18.2.1",
     "core-js": "^2.5.5",
     "faker": "^3.0.1",
     "hoek": "^5.0.3",


### PR DESCRIPTION
Hey there!

We recently upgraded blockstack.js to gracefully handle failures in the case of Gaia tokens being invalidated. With this upgrade, if Gaia tokens are ever invalidated, `blockstack.js` will automatically generate a new token and retry a write to Gaia.

Without this change, all writes will fail until the user logs out and back in.

I think this upgrade is rather important, so that your app can gracefully handle Gaia authentication errors due to token invalidations.

Hope all is well,

Hank